### PR TITLE
Add more versions of Python to test against.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@
 language: python
 python:
   - "3.2"
+  - "3.3"
 install: python3 setup.py install
 script:  python3 setup.py test


### PR DESCRIPTION
The main beauty of CI is that it allows against more than one version of the system at once (here also Python 3.3, unfortunately 3.1 is not supported anymore).
