### PR TITLE
setup.py: Fixup license long text.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='ofxstatement',
           'Topic :: Utilities',
           'Environment :: Console',
           'Operating System :: OS Independent',
-          'License :: OSI Approved :: GNU Affero General Public License v3'],
+          'License :: OSI Approved :: GNU General Public License v3'],
       packages=find_packages('src'),
       namespace_packages=["ofxstatement", "ofxstatement.plugins"],
       entry_points={


### PR DESCRIPTION
You specify the license as GPL v3, but in long description there is Affero version mentioned.

The same problem exists in plugins.