### PR TITLE
Fix config file location for appdirs >= 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(name='ofxstatement',
           },
       package_dir={'': 'src'},
       install_requires=['setuptools',
-                        'appdirs'
+                        'appdirs>=1.3.0'
                         ],
       extras_require={'test': ["mock"]},
       tests_require=["mock"],

--- a/src/ofxstatement/configuration.py
+++ b/src/ofxstatement/configuration.py
@@ -9,7 +9,7 @@ APP_AUTHOR = 'ofx'
 
 
 def get_default_location():
-    cdir = appdirs.user_data_dir(APP_NAME, APP_AUTHOR)
+    cdir = appdirs.user_config_dir(APP_NAME, APP_AUTHOR)
     return os.path.join(cdir, 'config.ini')
 
 


### PR DESCRIPTION
Before appdirs 1.3.0, the method user_data_dir returned the config
directory on Unix. In appdirs 1.3.0 and later, this changed in order to
respect the XDG Base Directory Specification.

user_data_dir now returns the value of $XDG_DATA_HOME [1] and the newly
introduced user_config_dir method returns the config directory as
configured by $XDG_CONFIG_HOME [2].

[1] https://github.com/ActiveState/appdirs/commit/74cfeb8c45ed3a03866ebc763820a0eeacc597c9
[2] https://github.com/ActiveState/appdirs/commit/a834517d5e5cd8f22fa7804471e51e3b05c5ebcc