### PR TITLE
setup.py: Fix build error in non-utf8 environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class RunTests(TestCommand):
 
 version = "0.6.0.dev"
 
-with open("CHANGES.rst") as chlogf, open('README.rst') as rdmef:
+with open("CHANGES.rst") as chlogf, open('README.rst', encoding = 'utf-8') as rdmef:
     long_description = chlogf.read() + "\n\n" + rdmef.read()
 
 setup(name='ofxstatement',


### PR DESCRIPTION
setup.py fails if you call it in non-utf8 environment:
```
$ LANG=C python3 setup.py clean
Traceback (most recent call last):
  File "setup.py", line 28, in <module>
    long_description = chlogf.read() + "\n\n" + rdmef.read()
  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 2950: ordinal not in range(128)
```

This commit fixes the error.