### PR TITLE
Use Decimal instead of floats to avoid rounding errors

### DIFF
--- a/src/ofxstatement/parser.py
+++ b/src/ofxstatement/parser.py
@@ -1,4 +1,5 @@
 import csv
+from decimal import Decimal, Decimal as D
 from datetime import datetime
 
 from ofxstatement.statement import Statement, StatementLine
@@ -45,8 +46,8 @@ class StatementParser(object):
         tp = type(getattr(StatementLine, field))
         if tp == datetime:
             return self.parse_datetime(value)
-        elif tp == float:
-            return self.parse_float(value)
+        elif tp == Decimal:
+            return self.parse_decimal(value)
         else:
             return value
 
@@ -54,7 +55,12 @@ class StatementParser(object):
         return datetime.strptime(value, self.date_format)
 
     def parse_float(self, value):
-        return float(value)
+        # compatibility wrapper for old plugins
+        return self.parse_decimal(value)
+
+    def parse_decimal(self, value):
+        # some plugins pass localised numbers, clean them up
+        return D(value.replace(",", ".").replace(" ", ""))
 
 
 class CsvStatementParser(StatementParser):

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -1,6 +1,7 @@
 """Statement model"""
 
 from datetime import datetime
+from decimal import Decimal as D
 
 
 TRANSACTION_TYPES = [
@@ -65,7 +66,7 @@ class StatementLine(object):
     memo = ""
 
     # Amount of transaction
-    amount = 0.0
+    amount = D(0)
 
     # additional fields
     payee = ""
@@ -169,7 +170,7 @@ def recalculate_balance(stmt):
 
     total_amount = sum(sl.amount for sl in stmt.lines)
 
-    stmt.start_balance = stmt.start_balance or 0.0
+    stmt.start_balance = stmt.start_balance or D(0)
     stmt.end_balance = stmt.start_balance + total_amount
     stmt.start_date = min(sl.date for sl in stmt.lines)
     stmt.end_date = max(sl.date for sl in stmt.lines)

--- a/src/ofxstatement/tests/test_parser.py
+++ b/src/ofxstatement/tests/test_parser.py
@@ -27,7 +27,7 @@ def doctest_CsvStatementParser():
         >>> len(statement.lines)
         2
         >>> statement.lines[0].amount
-        243.32
+        Decimal('243.32')
         >>> statement.lines[1].payee
         'Google'
 


### PR DESCRIPTION
As Louis Opter notes, floats can only approximate their value and aren't meant to be used for accounting. I’m submitting his patch with a couple of changes:

* provide `parse_float()` compatibility wrapper, as many plugins rely on it
* delocalise the input from some plugins, as a couple of plugins pass localised number strings