### PR TITLE
Handle more complicated EDITOR environment variable

### DIFF
--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -2,6 +2,7 @@
 """
 import os
 import argparse
+import shlex
 import subprocess
 import logging
 
@@ -89,7 +90,7 @@ def edit_config(args):
         log.info("Creating confugration directory: %s" % configdir)
         os.makedirs(configdir, mode=0o700)
     log.info("Running editor: %s %s" % (editor, configfname))
-    subprocess.call([editor, configfname])
+    subprocess.call(shlex.split(editor) + [configfname])
 
 
 def convert(args):


### PR DESCRIPTION
This fixes `ofxstatement edit-config` when the EDITOR environment
varilable contains more than just a progname (e.g: `mvim -f`).