### PR TITLE
Make StatementLine.date_user a datetime object

### DIFF
--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -72,7 +72,7 @@ class StatementLine(object):
     payee = ""
 
     # Date user initiated transaction, if known
-    date_user = ""
+    date_user = datetime.now()
 
     # Check (or other reference) number
     check_no = ""


### PR DESCRIPTION
Not sure why this was left as a string?