### PR TITLE
Add support for account type

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -72,7 +72,7 @@ class OfxWriter(object):
         tb.start("BANKACCTFROM", {})
         self.buildText("BANKID", self.statement.bank_id, False)
         self.buildText("ACCTID", self.statement.account_id, False)
-        self.buildText("ACCTTYPE", "CHECKING")
+        self.buildText("ACCTTYPE", self.statement.account_type)
         tb.end("BANKACCTFROM")
 
         tb.start("BANKTRANLIST", {})

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -40,7 +40,7 @@ class Statement(object):
     bank_id = None
     account_id = None
     # Type of account, must be one of ACCOUNT_TYPE
-    account_type = "CHECKING"
+    account_type = None
 
     start_balance = None
     start_date = None
@@ -48,11 +48,13 @@ class Statement(object):
     end_balance = None
     end_date = None
 
-    def __init__(self, bank_id=None, account_id=None, currency=None):
+    def __init__(self, bank_id=None, account_id=None,
+                 currency=None, account_type="CHECKING"):
         self.lines = []
         self.bank_id = bank_id
         self.account_id = account_id
         self.currency = currency
+        self.account_type = account_type
 
 
 class StatementLine(object):

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -39,6 +39,8 @@ class Statement(object):
     currency = None
     bank_id = None
     account_id = None
+    # Type of account, must be one of ACCOUNT_TYPE
+    account_type = "CHECKING"
 
     start_balance = None
     start_date = None


### PR DESCRIPTION
The account type (ACCTTYPE) is currently hard coded to CHECKING. This pull request adds support for setting the account type in the Statement class. By default the account type is set to CHECKING in order not to break the current tests.