### PR TITLE
Added download to plugin structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ eggs
 .project
 .pydevproject
 *.sublime*
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,15 @@ After installation, usage is simple::
 Resulting ``statement.ofx`` is then ready to be imported to GnuCash or other
 financial program you use.
 
+Plugins could have download capability in this case you can download
+statements from bank site::
+
+  $ ofxstatement download -t <plugin> --date-from 01/01/2019 --date-to 01/02/2019 out.xls
+
+Resulting file ``out.xls`` is then ready to be converted with the 
+``ofxstatement convert`` command.
+Note, that download functionality is plugin specific. See particular plugin
+documentation for more info.
 
 Known Plugins
 =============
@@ -201,7 +210,7 @@ imported .ofx statement with particular GnuCash account.
 
 To convert proprietary ``danske.csv`` to OFX ``danske.ofx``, run::
 
-    $ ofxstatement -t danske:usd danske.csv danske.ofx
+    $ ofxstatement convert -t danske:usd danske.csv danske.ofx
 
 Note, that configuration parameters are plugin specific. See particular plugin
 documentation for more info.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(name='ofxstatement',
           },
       package_dir={'': 'src'},
       install_requires=['setuptools',
-                        'appdirs>=1.3.0'
+                        'appdirs>=1.3.0',
+                        'datetime'
                         ],
       extras_require={'test': ["mock", "pytest", "pytest-cov"]},
       tests_require=["mock"],

--- a/src/ofxstatement/configuration.py
+++ b/src/ofxstatement/configuration.py
@@ -20,7 +20,7 @@ def read(location=None):
     if not os.path.exists(location):
         return None
 
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.read(location)
     return config
 

--- a/src/ofxstatement/downloader.py
+++ b/src/ofxstatement/downloader.py
@@ -1,0 +1,16 @@
+class Downloader(object):
+    """Abstract statement downloader.
+
+    Defines interface for all parser implementation
+    """
+
+    def download(self):
+        """download statement file
+
+        Return Statement object
+
+        May raise exceptions.DownloadError if there are problems
+        in downloading statement file.
+        """
+        raise NotImplementedError
+

--- a/src/ofxstatement/exceptions.py
+++ b/src/ofxstatement/exceptions.py
@@ -8,3 +8,9 @@ class ParseError(Exception):
     def __init__(self, lineno, message):
         self.lineno = lineno
         self.message = message
+
+class DownloadError(Exception):
+    """Raised by downloader to indicate problem on web scraper
+    """
+    def __init__(self, message):
+        self.message = message

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -45,4 +45,7 @@ class Plugin(object):
         self.settings = settings
 
     def get_parser(self, filename):
-        raise NotImplementedError()
+        raise NotImplementedError
+
+    def get_downloader(self, filename, date_from, date_to):
+        raise NotImplementedError


### PR DESCRIPTION
If this can be useful i added the (optional) capability to download statements directly from bank site in plugins. All work is done by the plugin overriding "Downloader" class.

-Added Downloader class to plugin structure (optional)
-use "ConfigParser" instead of SafeConfigParser to avoid warning in pytest
-added command line options for download capability
-Updated Readme