### PR TITLE
Add German Triodos script to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,8 @@ Plugin                            Description
 `ofxstatement-dab`_               DAB Bank (Germany)
 `ofxstatement-consors`_           Consorsbank (Germany)
 `ofxstatement-is-arionbanki`_     Arion bank in Iceland
-`ofxstatement-be-triodos`_        Triodos Bank CSV statements
+`ofxstatement-be-triodos`_        Belgian Triodos Bank CSV statements
+`ofxstatement-de-triodos`_        German Triodos Bank CSV statements (also works for GLS Bank)
 `ofxstatement-lansforsakringar`_  Länsförsäkringar (Sweden), it parses Kontoutdrag.xls for private accounts
 `ofxstatement-revolut`_           Revolut Mastercard
 `ofxstatement-sp-freiburg`_       Sparkasse Freiburg-Nördlicher Breisgau (Germany)
@@ -159,6 +160,7 @@ Plugin                            Description
 .. _ofxstatement-consors: https://github.com/JohannesKlug/ofxstatement-consors
 .. _ofxstatement-is-arionbanki: https://github.com/Dagur/ofxstatement-is-arionbanki
 .. _ofxstatement-be-triodos: https://github.com/renardeau/ofxstatement-be-triodos
+.. _ofxstatement-de-triodos: https://github.com/pianoslum/ofxstatement-de-triodos
 .. _ofxstatement-lansforsakringar: https://github.com/lbschenkel/ofxstatement-lansforsakringar
 .. _ofxstatement-revolut: https://github.com/mlaitinen/ofxstatement-revolut
 .. _ofxstatement-sp-freiburg: https://github.com/omarkohl/ofxstatement-sparkasse-freiburg


### PR DESCRIPTION
Thanks to https://github.com/renardeau for his original script.
However the csv exported from the German Triodos seems to be different from the Belgian one, so I uploaded my own version.