### PR TITLE
Improved handling of edit-config command and ability to write to standard output.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,10 @@ accounting system.
 Development / test
 ==================
 
-When you want to develop, first fork this repository and then::
+When you want to develop, first fork this repository to your GitHub
+environment and then::
 
-  $ git clone https://github.com/<yourname>/ofxstatement.git
+  $ git clone https://github.com/<your_account>/ofxstatement.git
   $ cd ofxstatement
   $ pip install -e .
 

--- a/README.rst
+++ b/README.rst
@@ -7,22 +7,23 @@ OFX Statement
 .. image:: https://coveralls.io/repos/kedder/ofxstatement/badge.png?branch=master
     :target: https://coveralls.io/r/kedder/ofxstatement?branch=master
 
-Ofxstatement is a tool to convert proprietary bank statement to OFX format,
-suitable for importing to GnuCash. Package provides single command line tool to
-run: ``ofxstatement``. Run ``ofxstatement -h`` to see basic usage description.
-``ofxstatement`` works under Python 3 and is not compatible with Python 2.
+Ofxstatement is a tool to convert proprietary bank statements to OFX format,
+suitable for importing into personal accounting systems like GnuCash. This
+package provides a command line tool to run: ``ofxstatement``. Run
+``ofxstatement -h`` for more help.  ``ofxstatement`` works under Python 3 and
+is not compatible with Python 2.
 
 
 Rationale
 =========
 
 Most internet banking systems are capable of exporting account transactions to
-some sort of computer readable formats, but few supports standard data formats,
-like `OFX`_.  On the other hand, personal accounting tools, such as `GnuCash`_
+some sort of computer readable format, but few support standard data formats,
+like `OFX`_.  On the other hand, personal accounting systems such as `GnuCash`_
 support standard formats only, and will probably never support proprietary
 statement formats of online banking systems.
 
-To bridge the gap between them, ofxstatement tool was created.
+To bridge the gap between them, this ofxstatement tool was created.
 
 .. _GnuCash: http://gnucash.org/
 .. _OFX: http://en.wikipedia.org/wiki/Open_Financial_Exchange
@@ -33,44 +34,63 @@ Mode of Operation
 The ``ofxstatement`` tool is intended to be used in the following workflow:
 
 1. At the end of each month, use your online banking service to export
-   statements from all of your bank accounts to files in formats, known to
+   statements from all of your bank accounts in a format known to
    ofxstatement.
 
-2. Run ``ofxstatement`` on each exported file to convert it to standard OFX
-   format.  Shell scripts or Makefile may help to automate this routine.
+2. Run ``ofxstatement`` on each exported file to convert it to OFX.
+   Shell scripts or a Makefile may help to automate this routine.
 
-3. Import generated OFX files to GnuCash or other accounting system.
+3. Import the generated OFX file into your personal accounting system.
 
 Installation and Usage
 ======================
 
-Before using ``ofxstatement``, you have to install plugin for your bank (or
+Before using ``ofxstatement``, you have to install a plugin for your bank (or
 write your own!). Plugins are installed as regular python eggs, with
 easy_install or pip, for example::
 
   $ pip3 install ofxstatement-lithuanian
 
-Note, that ofxstatement itself will be installed automatically this way. After
-installation, ``ofxstatement`` utility should be available.
+Note that ofxstatement itself will be installed automatically this way. After
+the installation, the ``ofxstatement`` utility will be available.
 
 Users of *Ubuntu* and *Debian* operating systems can install ofxstatement from 
 official package repositories::
 
   $ apt install ofxstatement ofxstatement-plugins 
 
-You can check ofxstatement is working by running::
+You can check that ofxstatement is working by running::
 
   $ ofxstatement list-plugins
 
-You should get a list of your installed plugins printed.
+You should get a list of your installed plugins.
 
-After installation, usage is simple::
+After installation, the usage is simple::
 
   $ ofxstatement convert -t <plugin> bank_statement.csv statement.ofx
 
-Resulting ``statement.ofx`` is then ready to be imported to GnuCash or other
-financial program you use.
+The resulting ``statement.ofx`` is then ready to be imported into a personal
+accounting system.
 
+
+Development / test
+==================
+
+When you want to develop, first fork this repository and then::
+
+  $ git clone https://github.com/<yourname>/ofxstatement.git
+  $ cd ofxstatement
+  $ pip install -e .
+
+Now you can install the test requirements::
+
+  $ pip install -r test_requirements.txt
+
+And finally run your test::
+
+  $ py.test
+
+When satisfied, you may create a pull request.
 
 Known Plugins
 =============
@@ -183,17 +203,19 @@ Advanced Configuration
 
 While ofxstatement can be used without any configuration, some plugins may
 accept additional configuration parameters. These parameters can be specified
-in configuration file. Configuration file can be edited using ``edit-config``
-command, that brings your favored editor with configuration file open::
+in a configuration file. The configuration file can be edited using the ``edit-config``
+command that opens your favorite editor (defined by environment variable
+EDITOR or else the default for your platform) with the configuration file::
 
   $ ofxstatement edit-config
 
-Configuration file format is a standard .ini format. Configuration is divided
-to sections, that corresponds to ``--type`` command line parameter. Each
-section must provide ``plugin`` option that points to one of the registered
-conversion plugins. Other parameters are plugin specific.
+The configuration file format is in the standard .ini format. The
+configuration is divided into sections that correspond to the ``--type``
+command line parameter. Each section must provide a ``plugin`` option that
+points to one of the registered conversion plugins. Other parameters are
+plugin specific.
 
-Sample configuration file::
+A sample configuration file::
 
     [swedbank]
     plugin = swedbank
@@ -205,26 +227,26 @@ Sample configuration file::
     account = LT123456789012345678
 
 
-Such configuration will let ofxstatement to know about two statement file
-format, handled by plugins ``swedbank`` and ``litas-esis``. ``litas-esis``
-plugin will load statements using ``cp1257`` charset and set custom currency
-and custom account number. This way, GnuCash will automatically associate
-imported .ofx statement with particular GnuCash account.
+Such a configuration will let ofxstatement know about two statement file
+formats handled by the plugins ``swedbank`` and ``litas-esis``. The ``litas-esis``
+plugin will load statements using the ``cp1257`` charset and set a custom currency
+and account number. This way, GnuCash will automatically associate the
+generated .ofx file with a particular GnuCash account.
 
-To convert proprietary ``danske.csv`` to OFX ``danske.ofx``, run::
+To convert the proprietary CSV file ``danske.csv`` into the OFX file ``danske.ofx``, run::
 
     $ ofxstatement -t danske:usd danske.csv danske.ofx
 
-Note, that configuration parameters are plugin specific. See particular plugin
+Note that configuration parameters are plugin specific. See the plugin
 documentation for more info.
 
 Writing your own Plugin
 =======================
 
-If plugin for your bank is not yet developed (see `Known plugins`_ section
-above), you can easily write your own, provided some knowledge about python
-programming language. There is an `ofxstatement-sample`_ plugin project
-available, that provides sample boilerplate and describes plugin development
-process in detail.
+If the plugin for your bank has not been developed yet (see `Known plugins`_
+section above) you can easily write your own, provided you have some knowledge
+about the Python programming language. There is an `ofxstatement-sample`_
+plugin project available that provides sample boilerplate and describes the
+plugin development process in detail.
 
 .. _ofxstatement-sample: https://github.com/kedder/ofxstatement-sample

--- a/src/ofxstatement/tests/test_tool.py
+++ b/src/ofxstatement/tests/test_tool.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import unittest
 import tempfile
 import io
@@ -156,7 +157,8 @@ class ToolTests(unittest.TestCase):
             tool.run(['edit-config'])
 
         self.assertEqual(makedirs.mock_calls, [])
-        call.assert_called_once_with(["vim", confpath])
+        editors = { 'Linux': 'vim', 'Darwin': 'vi', 'Windows': 'notepad' }
+        call.assert_called_once_with([editors[platform.system()], confpath])
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(suffix='ofxstatement')

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -5,6 +5,7 @@ import argparse
 import shlex
 import subprocess
 import logging
+import platform
 
 import pkg_resources
 
@@ -83,14 +84,15 @@ def list_plugins(args):
 
 
 def edit_config(args):
-    editor = os.environ.get('EDITOR', 'vim')
+    editors = { 'Linux': 'vim', 'Darwin': 'vi', 'Windows': 'notepad' }
+    editor = os.environ.get('EDITOR', editors[platform.system()])
     configfname = configuration.get_default_location()
     configdir = os.path.dirname(configfname)
     if not os.path.exists(configdir):
         log.info("Creating confugration directory: %s" % configdir)
         os.makedirs(configdir, mode=0o700)
     log.info("Running editor: %s %s" % (editor, configfname))
-    subprocess.call(shlex.split(editor, posix=os.name=='posix') + [configfname])
+    subprocess.call(shlex.split(editor, posix=(os.name=='posix')) + [configfname])
 
 
 def convert(args):

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -64,10 +64,10 @@ def make_args_parser():
     parser_convert.add_argument("-t", "--type",
                                 required=True,
                                 help=("input file type. This is a section in "
-                                      "config file, or plugin name if you "
+                                      "the config file or plugin name if you "
                                       "have no config file."))
     parser_convert.add_argument("input", help="input file to process")
-    parser_convert.add_argument("output", help="output (OFX) file to produce")
+    parser_convert.add_argument("output", help="output (OFX) file to produce where a minus (-) means writing to standard output instead")
     parser_convert.set_defaults(func=convert)
 
     # list-plugins

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -6,6 +6,8 @@ import shlex
 import subprocess
 import logging
 import platform
+import sys
+import contextlib
 
 import pkg_resources
 
@@ -13,6 +15,22 @@ from ofxstatement import ui, configuration, plugin, ofx, exceptions
 
 
 log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def smart_open(filename=None):
+    """See https://stackoverflow.com/questions/17602878/how-to-handle-both-with-open-and-sys-stdout-nicely
+    """
+    if filename and filename != '-':
+        fh = open(filename, 'w')
+    else:
+        fh = sys.stdout
+
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
 
 
 def get_version():
@@ -133,7 +151,7 @@ def convert(args):
         log.error("Parse error on line %s: %s" % (e.lineno, e.message))
         return 2  # error
 
-    with open(args.output, "w") as out:
+    with smart_open(args.output) as out:
         writer = ofx.OfxWriter(statement)
         out.write(writer.toxml())
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+mock
+pytest
+pytest-cov


### PR DESCRIPTION
First of all, I would like to thank the author, Andrey Lebedev, for his work. This tool is a very nice solution for a problem which should not have been there.

I want to use this tool for the personal accounting system I use: Beancount. Beancount has a semi-automatic importer called beancount-import (another project) that can quite well import OFX files. Other formats are supported as well as long as you provide an import handler. In order to let the open source community profit of my work, I thought it would be better to write some ofxconverter plugins and use them in beancount-import. I plan to deliver dutch plugins, a french plugin and a plugin for MT940, another common standard.

But, I needed some changes in ofxconverter first:
- ofxconvert edit-config did not work on Windows, nor was the environment variable documented
- there was no way to convert to standard output, hence the output file '-' will accomplish that
- I took the liberty to improve the documentation

I hope it helps.