### PR TITLE
Function generate_unique_transaction_id returns only the counter on a duplicate.

### DIFF
--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -229,7 +229,7 @@ def generate_unique_transaction_id(stmt_line, unique_id_set: set):  # pragma: no
         id = initial_id + str(counter)
 
     unique_id_set.add(id)
-    return id + '' if counter == 0 else '-' + str(counter)
+    return id + ('' if counter == 0 else '-' + str(counter))
 
 
 def recalculate_balance(stmt):


### PR DESCRIPTION
Two parentheses were forgotten in generate_unique_transaction_id, hence it just returned the counter with a minus in front of it.