### PR TITLE
Support OFX CURRENCY and ORIGCURRENCY in statement lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 0.7.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Support OFX CURRENCY and ORIGCURRENCY in statement lines. This allows plugins
+  to add information about transaction currency to generated OFX statements.
 
 
 0.7.1 (2020-09-14)

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from xml.etree import ElementTree as etree
 
-from ofxstatement.statement import Statement, StatementLine, BankAccount
+from ofxstatement.statement import Statement, StatementLine, BankAccount, Currency
 
 
 class OfxWriter(object):
@@ -109,13 +109,22 @@ class OfxWriter(object):
         self.buildText("NAME", line.payee)
         self.buildText("MEMO", line.memo)
         self.buildText("REFNUM", line.refnum)
-        # self.buildText("CURRENCY", line.currency)
         if line.bank_account_to:
             tb.start("BANKACCTTO", {})
             self.buildBankAccount(line.bank_account_to)
             tb.end("BANKACCTTO")
+        if line.currency is not None:
+            self.buildCurrency("CURRENCY", line.currency)
+        if line.orig_currency is not None:
+            self.buildCurrency("ORIG_CURRENCY", line.orig_currency)
 
         tb.end("STMTTRN")
+
+    def buildCurrency(self, tag: str, currency: Currency) -> None:
+        self.tb.start(tag, {})
+        self.buildText("CURSYM", currency.symbol)
+        self.buildAmount("CURRATE", currency.rate)
+        self.tb.end(tag)
 
     def buildBankAccount(self, account: BankAccount) -> None:
         self.buildText("BANKID", account.bank_id)

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -120,6 +120,13 @@ class StatementLine(Printable):
     # Optional BankAccount instance
     bank_account_to: Optional["BankAccount"] = None
 
+    # Currency this line is expressed in (if different from statement
+    # currency). Available since 0.7.2
+    currency: Optional["Currency"] = None
+
+    # Original amount and the original (foreign) currency. Available since 0.7.2
+    orig_currency: Optional["Currency"] = None
+
     def __init__(
         self, id: str = None, date: datetime = None, memo: str = None, amount: D = None
     ) -> None:
@@ -157,6 +164,22 @@ class StatementLine(Printable):
             self.bank_account_to.assert_valid()
 
         assert self.id or self.check_no or self.refnum
+
+
+class Currency(Printable):
+    """CURRENCY and ORIGCURRENCY aggregates from OFX
+
+    See section 5.2 from OFX spec version 2.2.
+    """
+
+    # ISO-4217 3-letter currency identifier
+    symbol: str
+    # Ratio of statement currency to `symbol` currency
+    rate: Optional[D]
+
+    def __init__(self, symbol: str, rate: D = None) -> None:
+        self.symbol = symbol
+        self.rate = rate
 
 
 class BankAccount(Printable):

--- a/src/ofxstatement/tests/test_ofx.py
+++ b/src/ofxstatement/tests/test_ofx.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from datetime import datetime
 
-from ofxstatement.statement import Statement, StatementLine, BankAccount
+from ofxstatement.statement import Statement, StatementLine, BankAccount, Currency
 from ofxstatement import ofx
 
 SIMPLE_OFX = """<?xml version="1.0" ?>
@@ -66,6 +66,13 @@ NEWFILEUID:NONE
                             <ACCTID>LT1232</ACCTID>
                             <ACCTTYPE>CHECKING</ACCTTYPE>
                         </BANKACCTTO>
+                        <CURRENCY>
+                            <CURSYM>USD</CURSYM>
+                        </CURRENCY>
+                        <ORIG_CURRENCY>
+                            <CURSYM>EUR</CURSYM>
+                            <CURRATE>3.45</CURRATE>
+                        </ORIG_CURRENCY>
                     </STMTTRN>
                 </BANKTRANLIST>
                 <LEDGERBAL>
@@ -96,6 +103,8 @@ class OfxWriterTest(TestCase):
         line.payee = ""
         line.bank_account_to = BankAccount("SNORAS", "LT1232")
         line.bank_account_to.branch_id = "VNO"
+        line.currency = Currency("USD")
+        line.orig_currency = Currency("EUR", Decimal("3.4543"))
         statement.lines.append(line)
 
         # Create writer:


### PR DESCRIPTION
See page 106 of OFX-2.2 spec (https://www.ofx.org/downloads/OFX%202.2.pdf).

Fixes #113