### PR TITLE
Ability to produce pretty OFX files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes
 
 - Support OFX CURRENCY and ORIGCURRENCY in statement lines. This allows plugins
   to add information about transaction currency to generated OFX statements.
-
+- Add `--pretty` flag to `convert` command to produce nicely intented OFX files.
 
 0.7.1 (2020-09-14)
 ==================

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -3,6 +3,7 @@ from datetime import datetime, date
 from decimal import Decimal
 
 from xml.etree import ElementTree as etree
+from xml.dom import minidom
 
 from ofxstatement.statement import (
     Statement,
@@ -21,10 +22,14 @@ class OfxWriter(object):
         self.default_float_precision = 2
         self.invest_transactions_float_precision = 5
 
-    def toxml(self) -> str:
+    def toxml(self, pretty: bool = False) -> str:
         et = self.buildDocument()
         encoded = etree.tostring(et.getroot(), "utf-8")
         encoded = str(encoded, "utf-8")
+        if pretty:
+            dom = minidom.parseString(encoded)
+            encoded = dom.toprettyxml(indent="  ")
+            encoded = encoded.replace('<?xml version="1.0" ?>', "").lstrip()
         header = (
             "<!-- \n"
             "OFXHEADER:100\n"

--- a/src/ofxstatement/tests/test_ofx.py
+++ b/src/ofxstatement/tests/test_ofx.py
@@ -114,3 +114,43 @@ class OfxWriterTest(TestCase):
         writer.genTime = datetime(2012, 3, 3, 0, 0, 0)
 
         assert prettyPrint(writer.toxml()) == SIMPLE_OFX
+
+    def test_ofxWriter_pretty(self) -> None:
+        # GIVEN
+        statement = Statement("BID", "ACCID", "LTL")
+        writer = ofx.OfxWriter(statement)
+        writer.genTime = datetime(2021, 9, 3, 0, 0, 0)
+
+        # WHEN
+        xml = writer.toxml(pretty=True)
+
+        # THEN
+        expected = [
+            "<!-- ",
+            "OFXHEADER:100",
+            "DATA:OFXSGML",
+            "VERSION:102",
+            "SECURITY:NONE",
+            "ENCODING:UTF-8",
+            "CHARSET:NONE",
+            "COMPRESSION:NONE",
+            "OLDFILEUID:NONE",
+            "NEWFILEUID:NONE",
+            "-->",
+            "",
+            "<OFX>",
+            "  <SIGNONMSGSRSV1>",
+            "    <SONRS>",
+            "      <STATUS>",
+            "        <CODE>0</CODE>",
+            "        <SEVERITY>INFO</SEVERITY>",
+            "      </STATUS>",
+            "      <DTSERVER>20210903000000</DTSERVER>",
+            "      <LANGUAGE>ENG</LANGUAGE>",
+            "    </SONRS>",
+            "  </SIGNONMSGSRSV1>",
+            "</OFX>",
+            "",
+        ]
+
+        assert xml.split("\n") == expected

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -79,6 +79,13 @@ def make_args_parser() -> argparse.ArgumentParser:
             "have no config file."
         ),
     )
+    parser_convert.add_argument(
+        "-p",
+        "--pretty",
+        action="store_true",
+        default=False,
+        help="produce pretty xml with nested tags properly indented.",
+    )
     parser_convert.add_argument("input", help="input file to process")
     parser_convert.add_argument(
         "output",
@@ -180,7 +187,7 @@ def convert(args: argparse.Namespace) -> int:
 
     with smart_open(args.output, settings.get("encoding", None)) as out:
         writer = ofx.OfxWriter(statement)
-        out.write(writer.toxml())
+        out.write(writer.toxml(pretty=args.pretty))
 
     log.info("Conversion completed: %s" % args.input)
     return 0  # success


### PR DESCRIPTION
Add `--pretty` flag to `convert` command to produce nicely intented OFX files.

Closes #63 