### PR TITLE
Support passing -c/--config arg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,6 +267,10 @@ To convert the proprietary CSV file ``danske.csv`` into the OFX file ``danske.of
 Note that configuration parameters are plugin specific. See the plugin
 documentation for more info.
 
+To use a custom configuration file, pass the ``-c`` / ``--config`` option::
+
+    $ ofxstatement convert -t pluginname -c /path/to/myconfig.ini input.csv output.ofx
+
 Writing your own Plugin
 =======================
 

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -75,6 +75,13 @@ def make_args_parser() -> argparse.ArgumentParser:
     parser_convert = subparsers.add_parser("convert", help="convert to OFX")
 
     parser_convert.add_argument(
+        "-c",
+        "--config",
+        metavar="myconfig.ini",
+        default=None,
+        help="custom config file to use",
+    )
+    parser_convert.add_argument(
         "-t",
         "--type",
         required=True,
@@ -145,7 +152,7 @@ def edit_config(args: argparse.Namespace) -> None:
 
 def convert(args: argparse.Namespace) -> int:
     appui = ui.UI()
-    config = configuration.read()
+    config = configuration.read(args.config)
 
     if config is None:
         # No configuration mode


### PR DESCRIPTION
Allow for passing a custom config file using the `-c` or `--config` argument.

In my case, this came in useful for scripting Transferwise (Wise) imports, where the files don't always have the same currency:

```bash
ofxstatement convert \
  -t transferwise \
  -c <(echo -e '[transferwise]\nplugin=transferwise\ncurrency=EUR') \
  statement.csv out.ofx
```