### PR TITLE
Show number of lines converted

### DIFF
--- a/src/ofxstatement/tests/test_tool.py
+++ b/src/ofxstatement/tests/test_tool.py
@@ -39,7 +39,7 @@ class ToolTests(unittest.TestCase):
         self.assertEqual(ret, 0)
         self.assertEqual(
             self.log.getvalue().splitlines(),
-            ["INFO: Conversion completed: %s" % inputfname],
+            ["INFO: Conversion completed: (0 lines) %s" % inputfname],
         )
 
     def test_convert_noconf(self) -> None:
@@ -65,7 +65,7 @@ class ToolTests(unittest.TestCase):
 
         self.assertEqual(
             self.log.getvalue().splitlines(),
-            ["INFO: Conversion completed: %s" % inputfname],
+            ["INFO: Conversion completed: (0 lines) %s" % inputfname],
         )
 
     def test_convert_parseerror(self) -> None:

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -195,7 +195,10 @@ def convert(args: argparse.Namespace) -> int:
         out.write(writer.toxml(pretty=args.pretty))
 
     n_lines = len(statement.lines)
-    log.info("Conversion completed: (%d line%s) %s" % (n_lines, "s" if n_lines != 1 else "", args.input))
+    log.info(
+        "Conversion completed: (%d line%s) %s"
+        % (n_lines, "s" if n_lines != 1 else "", args.input)
+    )
     return 0  # success
 
 

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -194,7 +194,8 @@ def convert(args: argparse.Namespace) -> int:
         writer = ofx.OfxWriter(statement)
         out.write(writer.toxml(pretty=args.pretty))
 
-    log.info("Conversion completed: %s" % args.input)
+    n_lines = len(statement.lines)
+    log.info("Conversion completed: (%d line%s) %s" % (n_lines, "s" if n_lines != 1 else "", args.input))
     return 0  # success
 
 


### PR DESCRIPTION
Thought it would be useful to have the tool show the number of converted lines; the Transferwise plugin for one does not output a warning when the currency does not match that of the input CSV.

Example output with this patch:

```
INFO: Conversion completed: (123 lines) /path/to/input.csv
```