### PR TITLE
Fix STMTTRN child order

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -126,13 +126,13 @@ class OfxWriter(object):
         self.buildAmount("TRNAMT", line.amount)
         self.buildText("FITID", line.id)
         self.buildText("CHECKNUM", line.check_no)
-        self.buildText("NAME", line.payee)
-        self.buildText("MEMO", line.memo)
         self.buildText("REFNUM", line.refnum)
+        self.buildText("NAME", line.payee)
         if line.bank_account_to:
             tb.start("BANKACCTTO", {})
             self.buildBankAccount(line.bank_account_to)
             tb.end("BANKACCTTO")
+        self.buildText("MEMO", line.memo)
         if line.currency is not None:
             self.buildCurrency("CURRENCY", line.currency)
         if line.orig_currency is not None:

--- a/src/ofxstatement/tests/test_ofx.py
+++ b/src/ofxstatement/tests/test_ofx.py
@@ -59,13 +59,13 @@ NEWFILEUID:NONE
                         <DTPOSTED>20120212</DTPOSTED>
                         <TRNAMT>25.00</TRNAMT>
                         <FITID>2</FITID>
-                        <MEMO>Sample 2</MEMO>
                         <BANKACCTTO>
                             <BANKID>SNORAS</BANKID>
                             <BRANCHID>VNO</BRANCHID>
                             <ACCTID>LT1232</ACCTID>
                             <ACCTTYPE>CHECKING</ACCTTYPE>
                         </BANKACCTTO>
+                        <MEMO>Sample 2</MEMO>
                         <CURRENCY>
                             <CURSYM>USD</CURSYM>
                         </CURRENCY>


### PR DESCRIPTION
Some parsers (notably libofx) use a [DTD](https://github.com/libofx/libofx/blob/master/dtd/ofx160.dtd) for parsing OFX files. This means that child element order is fixed, and the wrong order won't verify or parse. I've reordered `<STMTTRN>`'s children so that the order matches the above DTD and the OFX spec.