### PR TITLE
Fix invest transactions unit precision

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -260,10 +260,11 @@ class OfxWriter(object):
             line.unit_price,
             precision=self.invest_transactions_float_precision,
         )
-        self.buildAmount("UNITS",
+        self.buildAmount(
+            "UNITS",
             line.units,
             precision=self.invest_transactions_float_precision,
-            )
+        )
 
         self.buildAmount(
             "TOTAL",

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -260,7 +260,10 @@ class OfxWriter(object):
             line.unit_price,
             precision=self.invest_transactions_float_precision,
         )
-        self.buildAmount("UNITS", line.units)
+        self.buildAmount("UNITS",
+            line.units,
+            precision=self.invest_transactions_float_precision,
+            )
 
         self.buildAmount(
             "TOTAL",

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -87,7 +87,7 @@ NEWFILEUID:NONE
                             <SUBACCTFUND>OTHER</SUBACCTFUND>
                             <FEES>1.24000</FEES>
                             <UNITPRICE>138.28000</UNITPRICE>
-                            <UNITS>3.00</UNITS>
+                            <UNITS>3.00000</UNITS>
                             <TOTAL>-416.08000</TOTAL>
                         </INVBUY>
                     </BUYSTOCK>
@@ -107,7 +107,7 @@ NEWFILEUID:NONE
                             <SUBACCTFUND>OTHER</SUBACCTFUND>
                             <FEES>0.28000</FEES>
                             <UNITPRICE>225.63000</UNITPRICE>
-                            <UNITS>-5.00</UNITS>
+                            <UNITS>-5.00000</UNITS>
                             <TOTAL>1127.87000</TOTAL>
                         </INVSELL>
                     </SELLSTOCK>


### PR DESCRIPTION
This PR adds additional precision for OFX investment transactions. Currently it's holding two decimal places, but often units carry additional digits. Rounding at two decimal places will likely cause significant errors in asset totals.