### PR TITLE
Remove pkg resources

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ tomli = {markers="python_version < '3.11'"}
 [packages]
 ofxstatement = {editable = true,path = "."}
 exceptiongroup = "*"
-importlib_metadata = {version = ">=3.8", markers="python_version < '3.12'"}
+importlib_metadata = {version = ">=3.8", markers="python_version < '3.10'"}

--- a/Pipfile
+++ b/Pipfile
@@ -16,3 +16,4 @@ tomli = {markers="python_version < '3.11'"}
 [packages]
 ofxstatement = {editable = true,path = "."}
 exceptiongroup = "*"
+importlib_metadata = {version = ">=3.8", markers="python_version < '3.12'"}

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ pytest-cov = "*"
 mock = "*"
 black = "*"
 mypy = "*"
-types-pkg-resources = "*"
 types-mock = "*"
 exceptiongroup = {markers="python_version < '3.11'"}
 tomli = {markers="python_version < '3.11'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -253,7 +253,12 @@
             "version": "==4.1.0"
         },
         "tomli": {
-            "markers": "python_version < '3.11'"
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "types-mock": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a2f478d6c67f3d7fb4e3bc8dfd474a88a5902846c518162ac5c5f6bf7e1cbd72"
+            "sha256": "ad5c20d24aabe639944675c072fe7281c2a2caf625a5b2a3176ca2c1f82b2e51"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -262,20 +262,12 @@
         },
         "types-mock": {
             "hashes": [
-                "sha256:e5821fdfd57bd545b101dc42373b0112027a1e53e82afbd801c122840b3a2780",
-                "sha256:eeeac25480287bb721fb17fcda2e9768d70a476dcc14a2c1d0389535c54f8184"
+                "sha256:13ca379d5710ccb3f18f69ade5b08881874cb83383d8fb49b1d4dac9d5c5d090",
+                "sha256:3d116955495935b0bcba14954b38d97e507cd43eca3e3700fc1b8e4f5c6bf2c7"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==5.1.0.3"
-        },
-        "types-pkg-resources": {
-            "hashes": [
-                "sha256:0cb9972cee992249f93fff1a491bf2dc3ce674e5a1926e27d4f0866f7d9b6d9c",
-                "sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae"
-            ],
-            "index": "pypi",
-            "version": "==0.1.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==5.1.0.20240106"
         },
         "typing-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ad5c20d24aabe639944675c072fe7281c2a2caf625a5b2a3176ca2c1f82b2e51"
+            "sha256": "9eff26da7c0885e82355bd0e9d77d60f3ebee69507ba41b063a5a5599ccc6f6f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -48,6 +48,7 @@
                 "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31",
                 "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
             ],
+            "markers": "python_version < '3.10' and python_version >= '3.8'",
             "version": "==3.17.0"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -30,9 +30,25 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.2.0"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e",
+                "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '3.10'",
+            "version": "==7.0.1"
+        },
         "ofxstatement": {
             "editable": true,
             "path": "."
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31",
+                "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            ],
+            "version": "==3.17.0"
         }
     },
     "develop": {
@@ -253,7 +269,13 @@
             "version": "==4.1.0"
         },
         "tomli": {
-            "markers": "python_version < '3.11'"
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "types-mock": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -253,12 +253,7 @@
             "version": "==4.1.0"
         },
         "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==2.0.1"
+            "markers": "python_version < '3.11'"
         },
         "types-mock": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -253,17 +253,10 @@
             "version": "==4.1.0"
         },
         "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==2.0.1"
+            "markers": "python_version < '3.11'"
         },
         "types-mock": {
             "hashes": [
-                "sha256:13ca379d5710ccb3f18f69ade5b08881874cb83383d8fb49b1d4dac9d5c5d090",
-                "sha256:3d116955495935b0bcba14954b38d97e507cd43eca3e3700fc1b8e4f5c6bf2c7"
                 "sha256:13ca379d5710ccb3f18f69ade5b08881874cb83383d8fb49b1d4dac9d5c5d090",
                 "sha256:3d116955495935b0bcba14954b38d97e507cd43eca3e3700fc1b8e4f5c6bf2c7"
             ],

--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,7 @@ Plugin                            Description
 `ofxstatement-n26`_               N26 Bank (Italy)
 `ofxstatement-it-banks`_          Widiba and Webank (Italy)
 `ofxstatement-bancoposta`_        BancoPosta - Poste Italiane (Italy)
+`ofxstatement-hype`_              Hype - Banca Sella (Italy)
 
 `ofxstatement-betterment`_        Betterment (USA)
 `ofxstatement-us-first-republic`_ First Republic Bank (USA)
@@ -218,6 +219,7 @@ Plugin                            Description
 .. _ofxstatement-mastercard-de: https://github.com/FliegendeWurst/ofxstatement-mastercard-de
 .. _ofxstatement-sparkasse-de: https://github.com/FliegendeWurst/ofxstatement-sparkasse-de
 .. _ofxstatement-bancoposta: https://github.com/lorenzogiudici5/ofxstatement-bancoposta
+.. _ofxstatement-hype: https://github.com/lorenzogiudici5/ofxstatement-hype
 
 Advanced Configuration
 ======================

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages = find:
 python_requires = >=3.8, <4
 install_requires =
     appdirs>=1.3.0
+    importlib_metadata>=3.8;python_version<'3.10'
 data_files =
    
 [options.packages.find]

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -20,7 +20,7 @@ def get_plugin(name: str, ui: UI, settings: MutableMapping) -> "Plugin":
         raise PluginNotRegistered(name)
     if len(plugins) > 1:
         raise PluginNameConflict(plugins)
-    plugin = plugins[0].load()
+    plugin = plugins[0].load() # type: ignore[index] # index requires a int but class expects a string
     return plugin(ui, settings)
 
 

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -6,9 +6,9 @@ from typing import List, Tuple, Type
 from collections.abc import MutableMapping
 
 try:
-    from importlib.metadata import entry_points
-except ImportError:
     from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points # type: ignore[assignment] #need when importlib_metadata is present
 
 from ofxstatement.ui import UI
 from ofxstatement.parser import AbstractStatementParser

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -9,14 +9,15 @@ from importlib.metadata import entry_points
 from ofxstatement.ui import UI
 from ofxstatement.parser import AbstractStatementParser
 
+
 def get_plugin(name: str, ui: UI, settings: MutableMapping) -> "Plugin":
     plugins = entry_points(name=name)
-    if not plugins:  
+    if not plugins:
         raise PluginNotRegistered(name)
     if len(plugins) > 1:
         raise PluginNameConflict(plugins)
     plugin = plugins[0].load()
-    return plugin(ui,settings)
+    return plugin(ui, settings)
 
 
 def list_plugins() -> List[Tuple[str, Type["Plugin"]]]:

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -11,13 +11,11 @@ from ofxstatement.parser import AbstractStatementParser
 
 def get_plugin(name: str, ui: UI, settings: MutableMapping) -> "Plugin":
     plugins = entry_points(name=name)
-    print(plugins)
     if not plugins:  
         raise PluginNotRegistered(name)
     if len(plugins) > 1:
         raise PluginNameConflict(plugins)
-    #pcls = plugins.attr
-    plugin = plugins[0].attr.load()
+    plugin = plugins[0].load()
     return plugin(ui,settings)
 
 

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -10,12 +10,14 @@ from ofxstatement.ui import UI
 from ofxstatement.parser import AbstractStatementParser
 
 def get_plugin(name: str, ui: UI, settings: MutableMapping) -> "Plugin":
-    if not entry_points(group=name):  
+    plugins = entry_points(name=name)
+    print(plugins)
+    if not plugins:  
         raise PluginNotRegistered(name)
-    if len(entry_points(group=name)) > 1:
+    if len(plugins) > 1:
         raise PluginNameConflict(plugins)
-    pcls = entry_points(group=name).attr
-    plugin = pcls.load()
+    #pcls = plugins.attr
+    plugin = plugins[0].attr.load()
     return plugin(ui,settings)
 
 
@@ -24,7 +26,7 @@ def list_plugins() -> List[Tuple[str, Type["Plugin"]]]:
 
     [(name, plugin_class)]
     """
-    plugin_eps = list(entry_points(group="ofxstatement"))
+    plugin_eps = entry_points(group="ofxstatement")
     return sorted((ep.name, ep.load()) for ep in plugin_eps)
 
 

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -8,7 +8,7 @@ from collections.abc import MutableMapping
 try:
     from importlib_metadata import entry_points
 except ImportError:
-    from importlib.metadata import entry_points # type: ignore[assignment] #need when importlib_metadata is present
+    from importlib.metadata import entry_points  # type: ignore[assignment] #need when importlib_metadata is present
 
 from ofxstatement.ui import UI
 from ofxstatement.parser import AbstractStatementParser
@@ -20,7 +20,7 @@ def get_plugin(name: str, ui: UI, settings: MutableMapping) -> "Plugin":
         raise PluginNotRegistered(name)
     if len(plugins) > 1:
         raise PluginNameConflict(plugins)
-    plugin = plugins[0].load() # type: ignore[index] # index requires a int but class expects a string
+    plugin = plugins[0].load()  # type: ignore[index] # index requires a int but class expects a string
     return plugin(ui, settings)
 
 

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -4,7 +4,10 @@ Plugins are objects that configures and coordinates conversion machinery.
 """
 from typing import List, Tuple, Type
 from collections.abc import MutableMapping
-from importlib.metadata import entry_points
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 
 from ofxstatement.ui import UI
 from ofxstatement.parser import AbstractStatementParser

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -4,11 +4,12 @@ Plugins are objects that configures and coordinates conversion machinery.
 """
 from typing import List, Tuple, Type
 from collections.abc import MutableMapping
+import sys
 
-try:
+if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
-except ImportError:
-    from importlib.metadata import entry_points  # type: ignore[assignment] #need when importlib_metadata is present
+else:
+    from importlib.metadata import entry_points
 
 from ofxstatement.ui import UI
 from ofxstatement.parser import AbstractStatementParser

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -4,6 +4,7 @@ Plugins are objects that configures and coordinates conversion machinery.
 """
 from typing import List, Tuple, Type
 from collections.abc import MutableMapping
+
 try:
     from importlib.metadata import entry_points
 except ImportError:

--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -25,7 +25,7 @@ def list_plugins() -> List[Tuple[str, Type["Plugin"]]]:
     [(name, plugin_class)]
     """
     plugin_eps = list(entry_points(group="ofxstatement"))
-    return sorted((ep.name, ep.load) for ep in plugin_eps)
+    return sorted((ep.name, ep.load()) for ep in plugin_eps)
 
 
 class PluginNotRegistered(Exception):

--- a/src/ofxstatement/tests/test_plugin.py
+++ b/src/ofxstatement/tests/test_plugin.py
@@ -12,10 +12,8 @@ class PluginTest(unittest.TestCase):
                 return mock.Mock()
 
         ep = mock.Mock()
-        ep.load.return_value = SamplePlugin
-
-        ep_patch = mock.patch("pkg_resources.iter_entry_points", return_value=[ep])
-
+        ep.attr.load.return_value = SamplePlugin
+        ep_patch = mock.patch("ofxstatement.plugin.entry_points", return_value=[ep])
         with ep_patch:
             p = plugin.get_plugin("sample", mock.Mock("UI"), mock.Mock("Settings"))
             self.assertIsInstance(p, SamplePlugin)
@@ -23,7 +21,7 @@ class PluginTest(unittest.TestCase):
     def test_get_plugin_conflict(self) -> None:
         ep = mock.Mock()
 
-        ep_patch = mock.patch("pkg_resources.iter_entry_points", return_value=[ep, ep])
+        ep_patch = mock.patch("ofxstatement.plugin.entry_points", return_value=[ep, ep])
         with ep_patch:
             with self.assertRaises(plugin.PluginNameConflict):
                 plugin.get_plugin("conflicting", mock.Mock("UI"), mock.Mock("Settings"))

--- a/src/ofxstatement/tests/test_plugin.py
+++ b/src/ofxstatement/tests/test_plugin.py
@@ -12,7 +12,7 @@ class PluginTest(unittest.TestCase):
                 return mock.Mock()
 
         ep = mock.Mock()
-        ep.attr.load.return_value = SamplePlugin
+        ep.load.return_value = SamplePlugin
         ep_patch = mock.patch("ofxstatement.plugin.entry_points", return_value=[ep])
         with ep_patch:
             p = plugin.get_plugin("sample", mock.Mock("UI"), mock.Mock("Settings"))

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -9,7 +9,10 @@ import platform
 import sys
 import contextlib
 
-from importlib.metadata import version
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
 
 from ofxstatement import ui, configuration, plugin, ofx, exceptions
 from typing import Optional, TextIO, Generator

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -9,10 +9,11 @@ import platform
 import sys
 import contextlib
 
-try:
+if sys.version_info < (3, 10):
     from importlib_metadata import version
-except ImportError:
+else:
     from importlib.metadata import version
+
 
 from ofxstatement import ui, configuration, plugin, ofx, exceptions
 from typing import Optional, TextIO, Generator

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -10,9 +10,9 @@ import sys
 import contextlib
 
 try:
-    from importlib.metadata import version
-except ImportError:
     from importlib_metadata import version
+except ImportError:
+    from importlib.metadata import version
 
 from ofxstatement import ui, configuration, plugin, ofx, exceptions
 from typing import Optional, TextIO, Generator

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -9,7 +9,7 @@ import platform
 import sys
 import contextlib
 
-import pkg_resources
+from importlib.metadata import version
 
 from ofxstatement import ui, configuration, plugin, ofx, exceptions
 from typing import Optional, TextIO, Generator
@@ -41,8 +41,7 @@ def smart_open(
 
 
 def get_version() -> str:
-    dist = pkg_resources.get_distribution("ofxstatement")
-    return dist.version
+    return version("ofxstatement")
 
 
 def configure_logging(args: argparse.Namespace) -> None:


### PR DESCRIPTION
Updated plugins.py and tool.py to pkg_resources to use importlib.metadata instead. Fixed tests to reflect using entry_points call to populate list_plugins and get_plugins.

For reference on pkg_resources:
[https://setuptools.pypa.io/en/latest/pkg_resources.html#package-discovery-and-resource-access-using-pkg-resources](url)