### PR TITLE
Add InvestStatmentLine as possible return from parse_record to fix typing check errors.

### DIFF
--- a/src/ofxstatement/parser.py
+++ b/src/ofxstatement/parser.py
@@ -4,7 +4,7 @@ import csv
 from decimal import Decimal, Decimal as D
 from datetime import datetime
 
-from ofxstatement.statement import Statement, StatementLine
+from ofxstatement.statement import Statement, StatementLine, InvestStatementLine
 
 LT = TypeVar("LT")
 
@@ -53,7 +53,7 @@ class StatementParser(AbstractStatementParser, Generic[LT]):
         """Return iterable object consisting of a line per transaction"""
         raise NotImplementedError
 
-    def parse_record(self, line: LT) -> Optional[StatementLine]:  # pragma: no cover
+    def parse_record(self, line: LT) -> Optional[StatementLine|InvestStatementLine]:  # pragma: no cover
         """Parse given transaction line and return StatementLine object"""
         raise NotImplementedError
 


### PR DESCRIPTION
A StatementParser parse_record call should return either a StatementLine or InvestStatementLine upon call. Added missing InvestStatementLine type to return to silence typing check errors.