### PR TITLE
Return pkg_resources namespaces back

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,9 @@ project_urls =
 [options]
 package_dir = =src
 packages = find:
+namespace_packages =
+    ofxstatement
+    ofxstatement.plugins
 python_requires = >=3.8, <4
 install_requires =
     appdirs>=1.3.0

--- a/src/ofxstatement/__init__.py
+++ b/src/ofxstatement/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/src/ofxstatement/plugins/__init__.py
+++ b/src/ofxstatement/plugins/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
We can't get rid of them, because all the plugins rely on this namespace style.