### PR TITLE
Handle additional types of investment transactions

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -201,8 +201,8 @@ class OfxWriter(object):
         tb.end("INVSTMTMSGSRSV1")
 
     def buildInvestTransaction(self, line: InvestStatementLine) -> None:
-        # invest transactions must always have trntype and trntype_detailed
-        if line.trntype is None or line.trntype_detailed is None:
+        # invest transactions must always have trntype
+        if line.trntype is None:
             return
 
         tb = self.tb
@@ -224,6 +224,10 @@ class OfxWriter(object):
         elif line.trntype.startswith("SELL"):
             tran_type_detailed_tag_name = "SELLTYPE"
             inner_tran_type_tag_name = "INVSELL"
+        elif line.trntype == "TRANSFER":
+            # Transfer transactions don't have details or an envelope
+            tran_type_detailed_tag_name = None
+            inner_tran_type_tag_name = None
         else:
             tran_type_detailed_tag_name = "INCOMETYPE"
             inner_tran_type_tag_name = (
@@ -231,7 +235,8 @@ class OfxWriter(object):
             )
 
         tb.start(line.trntype, {})
-        self.buildText(tran_type_detailed_tag_name, line.trntype_detailed, False)
+        if tran_type_detailed_tag_name:
+            self.buildText(tran_type_detailed_tag_name, line.trntype_detailed, False)
 
         if inner_tran_type_tag_name:
             tb.start(inner_tran_type_tag_name, {})
@@ -277,11 +282,7 @@ class OfxWriter(object):
             precision=self.invest_transactions_float_precision,
         )
 
-        self.buildAmount(
-            "TOTAL",
-            line.amount,
-            False,
-        )
+        self.buildAmount("TOTAL", line.amount)
 
         if inner_tran_type_tag_name:
             tb.end(inner_tran_type_tag_name)

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -207,6 +207,15 @@ class OfxWriter(object):
 
         tb = self.tb
 
+        if line.trntype == "INVBANKTRAN":
+            tb.start(line.trntype, {})
+            bankTran = StatementLine(line.id, line.date, line.memo, line.amount)
+            bankTran.trntype = line.trntype_detailed
+            self.buildBankTransaction(bankTran)
+            self.buildText("SUBACCTFUND", "OTHER")
+            tb.end(line.trntype)
+            return
+
         tran_type_detailed_tag_name = None
         inner_tran_type_tag_name = None
         if line.trntype.startswith("BUY"):

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -155,6 +155,8 @@ class OfxWriter(object):
         for security_id in dict.fromkeys(
             map(lambda x: x.security_id, self.statement.invest_lines)
         ):
+            if security_id is None:
+                continue
             tb.start("STOCKINFO", {})
             tb.start("SECINFO", {})
             tb.start("SECID", {})

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -272,7 +272,6 @@ class OfxWriter(object):
             "TOTAL",
             line.amount,
             False,
-            precision=self.invest_transactions_float_precision,
         )
 
         if inner_tran_type_tag_name:

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -44,6 +44,8 @@ INVEST_TRANSACTION_TYPES_DETAILED = [
     "SELLSHORT",  # open short sale
     "DIV",  # only for INCOME
     "INTEREST",  # only for INCOME
+    "CGLONG",  # only for INCOME
+    "CGSHORT",  # only for INCOME
 ]
 
 ACCOUNT_TYPE = [

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -35,6 +35,7 @@ INVEST_TRANSACTION_TYPES = [
     "SELLSTOCK",
     "SELLDEBT",
     "INCOME",
+    "INVBANKTRAN",
 ]
 
 INVEST_TRANSACTION_TYPES_DETAILED = [
@@ -46,6 +47,15 @@ INVEST_TRANSACTION_TYPES_DETAILED = [
     "INTEREST",  # only for INCOME
     "CGLONG",  # only for INCOME
     "CGSHORT",  # only for INCOME
+]
+
+INVBANKTRAN_TYPES_DETAILED = [
+    "INT",
+    "XFER",
+    "DEBIT",
+    "CREDIT",
+    "SRVCHG",
+    "OTHER",
 ]
 
 ACCOUNT_TYPE = [
@@ -277,19 +287,35 @@ class InvestStatementLine(Printable):
             INVEST_TRANSACTION_TYPES,
         )
 
-        assert (
-            self.trntype_detailed in INVEST_TRANSACTION_TYPES_DETAILED
-        ), "trntype_detailed %s is not valid, must be one of %s" % (
-            self.trntype_detailed,
-            INVEST_TRANSACTION_TYPES_DETAILED,
-        )
+        if self.trntype == "INVBANKTRAN":
+            assert self.trntype_detailed in INVBANKTRAN_TYPES_DETAILED, (
+                "trntype_detailed %s is not valid for INVBANKTRAN, must be one of %s"
+                % (
+                    self.trntype_detailed,
+                    INVBANKTRAN_TYPES_DETAILED,
+                )
+            )
+        else:
+            assert (
+                self.trntype_detailed in INVEST_TRANSACTION_TYPES_DETAILED
+            ), "trntype_detailed %s is not valid, must be one of %s" % (
+                self.trntype_detailed,
+                INVEST_TRANSACTION_TYPES_DETAILED,
+            )
 
         assert self.id
-        assert self.security_id
+        assert self.date
         assert self.amount
+        assert self.trntype == "INVBANKTRAN" or self.security_id
 
-        assert self.trntype == "INCOME" or self.units
-        assert self.trntype == "INCOME" or self.unit_price
+        if self.trntype == "INVBANKTRAN":
+            pass
+        elif self.trntype == "INCOME":
+            assert self.security_id
+        else:
+            assert self.security_id
+            assert self.units
+            assert self.unit_price
 
 
 class BankAccount(Printable):

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -32,10 +32,11 @@ TRANSACTION_TYPES = [
 INVEST_TRANSACTION_TYPES = [
     "BUYSTOCK",
     "BUYDEBT",
-    "SELLSTOCK",
-    "SELLDEBT",
     "INCOME",
     "INVBANKTRAN",
+    "SELLSTOCK",
+    "SELLDEBT",
+    "TRANSFER",
 ]
 
 INVEST_TRANSACTION_TYPES_DETAILED = [
@@ -295,6 +296,10 @@ class InvestStatementLine(Printable):
                     INVBANKTRAN_TYPES_DETAILED,
                 )
             )
+        elif self.trntype == "TRANSFER":
+            assert (
+                self.trntype_detailed is None
+            ), f"trntype_detailed '{self.trntype_detailed}' should be empty for TRANSFERS"
         else:
             assert (
                 self.trntype_detailed in INVEST_TRANSACTION_TYPES_DETAILED
@@ -305,7 +310,7 @@ class InvestStatementLine(Printable):
 
         assert self.id
         assert self.date
-        assert self.amount
+        assert self.trntype == "TRANSFER" or self.amount
         assert self.trntype == "INVBANKTRAN" or self.security_id
 
         if self.trntype == "INVBANKTRAN":
@@ -315,7 +320,7 @@ class InvestStatementLine(Printable):
         else:
             assert self.security_id
             assert self.units
-            assert self.unit_price
+            assert self.trntype == "TRANSFER" or self.unit_price
 
 
 class BankAccount(Printable):

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -127,6 +127,16 @@ NEWFILEUID:NONE
                         <WITHHOLDING>0.50000</WITHHOLDING>
                         <TOTAL>0.79</TOTAL>
                     </INCOME>
+                    <INVBANKTRAN>
+                        <STMTTRN>
+                            <TRNTYPE>INT</TRNTYPE>
+                            <DTPOSTED>20210102</DTPOSTED>
+                            <TRNAMT>0.45</TRNAMT>
+                            <FITID>6</FITID>
+                            <MEMO>Bank Interest</MEMO>
+                        </STMTTRN>
+                        <SUBACCTFUND>OTHER</SUBACCTFUND>
+                    </INVBANKTRAN>
                 </INVTRANLIST>
             </INVSTMTRS>
         </INVSTMTTRNRS>
@@ -187,6 +197,13 @@ class OfxInvestLinesWriterTest(TestCase):
             Decimal("0.79"),
         )
         invest_line.fees = Decimal("0.5")
+        invest_line.assert_valid()
+        statement.invest_lines.append(invest_line)
+
+        invest_line = InvestStatementLine(
+            "6", datetime(2021, 1, 2), "Bank Interest", "INVBANKTRAN", "INT"
+        )
+        invest_line.amount = Decimal("0.45")
         invest_line.assert_valid()
         statement.invest_lines.append(invest_line)
 

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -88,7 +88,7 @@ NEWFILEUID:NONE
                             <FEES>1.24000</FEES>
                             <UNITPRICE>138.28000</UNITPRICE>
                             <UNITS>3.00000</UNITS>
-                            <TOTAL>-416.08000</TOTAL>
+                            <TOTAL>-416.08</TOTAL>
                         </INVBUY>
                     </BUYSTOCK>
                     <SELLSTOCK>
@@ -108,7 +108,7 @@ NEWFILEUID:NONE
                             <FEES>0.28000</FEES>
                             <UNITPRICE>225.63000</UNITPRICE>
                             <UNITS>-5.00000</UNITS>
-                            <TOTAL>1127.87000</TOTAL>
+                            <TOTAL>1127.87</TOTAL>
                         </INVSELL>
                     </SELLSTOCK>
                     <INCOME>
@@ -125,7 +125,7 @@ NEWFILEUID:NONE
                         <SUBACCTSEC>OTHER</SUBACCTSEC>
                         <SUBACCTFUND>OTHER</SUBACCTFUND>
                         <WITHHOLDING>0.50000</WITHHOLDING>
-                        <TOTAL>0.79000</TOTAL>
+                        <TOTAL>0.79</TOTAL>
                     </INCOME>
                 </INVTRANLIST>
             </INVSTMTRS>

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -137,6 +137,21 @@ NEWFILEUID:NONE
                         </STMTTRN>
                         <SUBACCTFUND>OTHER</SUBACCTFUND>
                     </INVBANKTRAN>
+                    <TRANSFER>
+                        <INVTRAN>
+                            <FITID>7</FITID>
+                            <DTTRADE>20210103</DTTRADE>
+                            <MEMO>Journaled Shares</MEMO>
+                        </INVTRAN>
+                        <SECID>
+                            <UNIQUEID>MSFT</UNIQUEID>
+                            <UNIQUEIDTYPE>TICKER</UNIQUEIDTYPE>
+                        </SECID>
+                        <SUBACCTSEC>OTHER</SUBACCTSEC>
+                        <SUBACCTFUND>OTHER</SUBACCTFUND>
+                        <UNITPRICE>225.63000</UNITPRICE>
+                        <UNITS>4.00000</UNITS>
+                    </TRANSFER>
                 </INVTRANLIST>
             </INVSTMTRS>
         </INVSTMTTRNRS>
@@ -204,6 +219,15 @@ class OfxInvestLinesWriterTest(TestCase):
             "6", datetime(2021, 1, 2), "Bank Interest", "INVBANKTRAN", "INT"
         )
         invest_line.amount = Decimal("0.45")
+        invest_line.assert_valid()
+        statement.invest_lines.append(invest_line)
+
+        invest_line = InvestStatementLine(
+            "7", datetime(2021, 1, 3), "Journaled Shares", "TRANSFER"
+        )
+        invest_line.security_id = "MSFT"
+        invest_line.units = Decimal("4")
+        invest_line.unit_price = Decimal("225.63")
         invest_line.assert_valid()
         statement.invest_lines.append(invest_line)
 

--- a/src/ofxstatement/tests/test_statement.py
+++ b/src/ofxstatement/tests/test_statement.py
@@ -51,6 +51,24 @@ class StatementTests(unittest.TestCase):
         self.assertTrue(tid2.endswith("-1"))
         self.assertEqual(len(txnids), 2)
 
+    def test_transfer_line_validation(self) -> None:
+        line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
+        line.trntype = "TRANSFER"
+        line.security_id = "ABC"
+        line.units = Decimal(2)
+        line.assert_valid()
+        with self.assertRaises(AssertionError):
+            line.security_id = None
+            line.assert_valid()
+        line.security_id = "ABC"
+        with self.assertRaises(AssertionError):
+            line.units = None
+            line.assert_valid()
+        line.units = Decimal(2)
+        with self.assertRaises(AssertionError):
+            line.trntype_detailed = "DETAIL"
+            line.assert_valid()
+
     def test_invbank_line_validation(self) -> None:
         line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
         line.trntype = "INVBANKTRAN"

--- a/src/ofxstatement/tests/test_statement.py
+++ b/src/ofxstatement/tests/test_statement.py
@@ -50,3 +50,70 @@ class StatementTests(unittest.TestCase):
 
         self.assertTrue(tid2.endswith("-1"))
         self.assertEqual(len(txnids), 2)
+
+    def test_invbank_line_validation(self) -> None:
+        line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
+        line.trntype = "INVBANKTRAN"
+        line.trntype_detailed = "INT"
+        line.amount = Decimal(1)
+        line.assert_valid()
+        with self.assertRaises(AssertionError):
+            line.amount = None
+            line.assert_valid()
+        line.amount = Decimal(1)
+        with self.assertRaises(AssertionError):
+            line.trntype_detailed = "BLAH"
+            line.assert_valid()
+
+    def test_income_line_validation(self) -> None:
+        line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
+        line.trntype = "INCOME"
+        line.trntype_detailed = "INTEREST"
+        line.amount = Decimal(1)
+        line.security_id = "AAPL"
+        line.assert_valid()
+        with self.assertRaises(AssertionError):
+            line.amount = None
+            line.assert_valid()
+        line.amount = Decimal(1)
+        with self.assertRaises(AssertionError):
+            line.trntype_detailed = "BLAH"
+            line.assert_valid()
+        line.trntype_detailed = "INTEREST"
+        with self.assertRaises(AssertionError):
+            line.security_id = None
+            line.assert_valid()
+
+    def test_buy_line_validation(self) -> None:
+        line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
+        line.trntype = "BUYSTOCK"
+        line.trntype_detailed = "BUY"
+        line.amount = Decimal(1)
+        line.security_id = "AAPL"
+        line.units = Decimal(3)
+        line.unit_price = Decimal(1.1)
+        line.assert_valid()
+
+        with self.assertRaises(AssertionError):
+            line.amount = None
+            line.assert_valid()
+        line.amount = Decimal(1)
+
+        with self.assertRaises(AssertionError):
+            line.trntype_detailed = "BLAH"
+            line.assert_valid()
+        line.trntype_detailed = "INTEREST"
+
+        with self.assertRaises(AssertionError):
+            line.security_id = None
+            line.assert_valid()
+        line.security_id = "AAPL"
+
+        with self.assertRaises(AssertionError):
+            line.units = None
+            line.assert_valid()
+        line.units = Decimal(3)
+
+        with self.assertRaises(AssertionError):
+            line.unit_price = None
+            line.assert_valid()


### PR DESCRIPTION
I'm in the process of building a plugin to convert Charles Schwab JSON exports to OFX, and need to write out some additional types of investment transactions in a way that is consumable by Gnucash.

Hopefully most if this is additive (i.e. shouldn't negatively impact current behavior) with the exception of limiting the precision of the total to 2 decimal places. IIRC, more than two decimal places on the total caused a problem importing into Gnucash.