### PR TITLE
Fix plugin loading

### DIFF
--- a/src/ofxstatement/plugin.py
+++ b/src/ofxstatement/plugin.py
@@ -22,7 +22,7 @@ def get_plugin(name: str, ui: UI, settings: MutableMapping) -> "Plugin":
         raise PluginNotRegistered(name)
     if len(plugins) > 1:
         raise PluginNameConflict(plugins)
-    plugin = plugins[0].load()  # type: ignore[index] # index requires a int but class expects a string
+    plugin = plugins[name].load()
     return plugin(ui, settings)
 
 

--- a/src/ofxstatement/tests/test_plugin.py
+++ b/src/ofxstatement/tests/test_plugin.py
@@ -2,6 +2,13 @@ import unittest
 
 import mock
 
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import EntryPoints
+else:
+    from importlib.metadata import EntryPoints
+
 from ofxstatement import plugin
 
 
@@ -13,7 +20,9 @@ class PluginTest(unittest.TestCase):
 
         ep = mock.Mock()
         ep.load.return_value = SamplePlugin
-        ep_patch = mock.patch("ofxstatement.plugin.entry_points", return_value=[ep])
+        ep_patch = mock.patch(
+            "ofxstatement.plugin.entry_points", return_value=EntryPoints([ep])
+        )
         with ep_patch:
             p = plugin.get_plugin("sample", mock.Mock("UI"), mock.Mock("Settings"))
             self.assertIsInstance(p, SamplePlugin)
@@ -21,7 +30,9 @@ class PluginTest(unittest.TestCase):
     def test_get_plugin_conflict(self) -> None:
         ep = mock.Mock()
 
-        ep_patch = mock.patch("ofxstatement.plugin.entry_points", return_value=[ep, ep])
+        ep_patch = mock.patch(
+            "ofxstatement.plugin.entry_points", return_value=EntryPoints([ep, ep])
+        )
         with ep_patch:
             with self.assertRaises(plugin.PluginNameConflict):
                 plugin.get_plugin("conflicting", mock.Mock("UI"), mock.Mock("Settings"))


### PR DESCRIPTION
After the switch to importlib, plugins are retrieved by name, not integer index.
For details see [importlib.metadata.EntryPoints.__getitem__()](https://github.com/python/cpython/blob/d2f1b0eb4956b4923f111c7c740ba7ab25f3312d/Lib/importlib/metadata/__init__.py#L260)

I discovered this when trying to run ofxstatement with my plugin and I got an error like:
```
.../importlib_metadata/__init__.py", line 269, in __getitem__
    raise KeyError(name)
KeyError: 0
```

I also had to make a tweak to the plugin test to make the mock more in line with importlib.