### PR TITLE
prefer the new unittest.mock from the standard library

### DIFF
--- a/src/ofxstatement/tests/test_plugin.py
+++ b/src/ofxstatement/tests/test_plugin.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 import sys
 

--- a/src/ofxstatement/tests/test_tool.py
+++ b/src/ofxstatement/tests/test_tool.py
@@ -7,8 +7,7 @@ import logging
 import logging.handlers
 import shutil
 from typing import Dict
-
-import mock
+from unittest import mock
 
 from ofxstatement import tool, statement, configuration, parser, exceptions
 


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.
