### PR TITLE
Add support for INVEXPENSE

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -233,11 +233,13 @@ class OfxWriter(object):
         tran_type_detailed_tag_name = None
         inner_tran_type_tag_name = None
         if line.trntype.startswith("BUY"):
-            tran_type_detailed_tag_name = "BUYTYPE"
             inner_tran_type_tag_name = "INVBUY"
+            if line.trntype == "BUYMF" or line.trntype == "BUYSTOCK":
+                tran_type_detailed_tag_name = "BUYTYPE"
         elif line.trntype.startswith("SELL"):
-            tran_type_detailed_tag_name = "SELLTYPE"
             inner_tran_type_tag_name = "INVSELL"
+            if line.trntype == "SELLMF" or line.trntype == "SELLSTOCK":
+                tran_type_detailed_tag_name = "SELLTYPE"
         elif line.trntype == "TRANSFER":
             # Transfer transactions don't have details or an envelope
             tran_type_detailed_tag_name = None

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -240,15 +240,15 @@ class OfxWriter(object):
             inner_tran_type_tag_name = "INVSELL"
             if line.trntype == "SELLMF" or line.trntype == "SELLSTOCK":
                 tran_type_detailed_tag_name = "SELLTYPE"
-        elif line.trntype == "TRANSFER":
-            # Transfer transactions don't have details or an envelope
-            tran_type_detailed_tag_name = None
-            inner_tran_type_tag_name = None
-        else:
+        elif line.trntype == "INCOME":
             tran_type_detailed_tag_name = "INCOMETYPE"
             inner_tran_type_tag_name = (
                 None  # income transactions don't have an envelope element
             )
+        else:
+            # INVEXPENSE and TRANSFER transactions don't have details or an envelope
+            tran_type_detailed_tag_name = None
+            inner_tran_type_tag_name = None
 
         tb.start(line.trntype, {})
         if tran_type_detailed_tag_name:

--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -267,7 +267,8 @@ class OfxWriter(object):
         tb.end("SECID")
 
         self.buildText("SUBACCTSEC", "OTHER")
-        self.buildText("SUBACCTFUND", "OTHER")
+        if line.trntype != "TRANSFER":
+            self.buildText("SUBACCTFUND", "OTHER")
 
         if line.fees:
             if line.trntype == "INCOME":

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -30,12 +30,14 @@ TRANSACTION_TYPES = [
 ]
 
 INVEST_TRANSACTION_TYPES = [
-    "BUYSTOCK",
     "BUYDEBT",
+    "BUYMF",
+    "BUYSTOCK",
     "INCOME",
     "INVBANKTRAN",
-    "SELLSTOCK",
     "SELLDEBT",
+    "SELLMF",
+    "SELLSTOCK",
     "TRANSFER",
 ]
 
@@ -301,7 +303,7 @@ class InvestStatementLine(Printable):
         )
 
         # Check transaction sub-types
-        if self.trntype == "BUYSTOCK":
+        if self.trntype == "BUYMF" or self.trntype == "BUYSTOCK":
             assert (
                 self.trntype_detailed in INVEST_TRANSACTION_BUYTYPES
             ), "trntype_detailed %s is not valid, must be one of %s" % (
@@ -323,7 +325,7 @@ class InvestStatementLine(Printable):
                     INVBANKTRAN_TYPES_DETAILED,
                 )
             )
-        elif self.trntype == "SELLSTOCK":
+        elif self.trntype == "SELLMF" or self.trntype == "SELLSTOCK":
             assert (
                 self.trntype_detailed in INVEST_TRANSACTION_SELLTYPES
             ), "trntype_detailed %s is not valid, must be one of %s" % (

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -39,15 +39,22 @@ INVEST_TRANSACTION_TYPES = [
     "TRANSFER",
 ]
 
-INVEST_TRANSACTION_TYPES_DETAILED = [
+INVEST_TRANSACTION_BUYTYPES = [
     "BUY",
     "BUYTOCOVER",  # end short sale
+]
+
+INVEST_TRANSACTION_SELLTYPES = [
     "SELL",
     "SELLSHORT",  # open short sale
-    "DIV",  # only for INCOME
-    "INTEREST",  # only for INCOME
-    "CGLONG",  # only for INCOME
-    "CGSHORT",  # only for INCOME
+]
+
+INVEST_TRANSACTION_INCOMETYPES = [
+    "CGLONG",
+    "CGSHORT",
+    "DIV",
+    "INTEREST",
+    "MISC",
 ]
 
 INVBANKTRAN_TYPES_DETAILED = [
@@ -300,12 +307,26 @@ class InvestStatementLine(Printable):
             assert (
                 self.trntype_detailed is None
             ), f"trntype_detailed '{self.trntype_detailed}' should be empty for TRANSFERS"
-        else:
+        elif self.trntype == "BUYSTOCK":
             assert (
-                self.trntype_detailed in INVEST_TRANSACTION_TYPES_DETAILED
+                self.trntype_detailed in INVEST_TRANSACTION_BUYTYPES
             ), "trntype_detailed %s is not valid, must be one of %s" % (
                 self.trntype_detailed,
-                INVEST_TRANSACTION_TYPES_DETAILED,
+                INVEST_TRANSACTION_BUYTYPES,
+            )
+        elif self.trntype == "INCOME":
+            assert (
+                self.trntype_detailed in INVEST_TRANSACTION_INCOMETYPES
+            ), "trntype_detailed %s is not valid, must be one of %s" % (
+                self.trntype_detailed,
+                INVEST_TRANSACTION_INCOMETYPES,
+            )
+        elif self.trntype == "SELLSTOCK":
+            assert (
+                self.trntype_detailed in INVEST_TRANSACTION_SELLTYPES
+            ), "trntype_detailed %s is not valid, must be one of %s" % (
+                self.trntype_detailed,
+                INVEST_TRANSACTION_SELLTYPES,
             )
 
         assert self.id

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -34,6 +34,7 @@ INVEST_TRANSACTION_TYPES = [
     "BUYMF",
     "BUYSTOCK",
     "INCOME",
+    "INVEXPENSE",
     "INVBANKTRAN",
     "SELLDEBT",
     "SELLMF",
@@ -303,6 +304,8 @@ class InvestStatementLine(Printable):
             self.assert_valid_income()
         elif self.trntype == "INVBANKTRAN":
             self.assert_valid_invbanktran()
+        elif self.trntype == "INVEXPENSE":
+            self.assert_valid_invexpense()
         elif self.trntype == "SELLDEBT":
             self.assert_valid_selldebt()
         elif self.trntype == "SELLMF" or self.trntype == "SELLSTOCK":
@@ -350,6 +353,13 @@ class InvestStatementLine(Printable):
             self.trntype_detailed,
             INVBANKTRAN_TYPES_DETAILED,
         )
+        assert self.amount
+
+    def assert_valid_invexpense(self):
+        assert (
+            self.trntype_detailed is None
+        ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
+        assert self.security_id
         assert self.amount
 
     def assert_valid_selldebt(self):

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -294,60 +294,97 @@ class InvestStatementLine(Printable):
         assert self.id
         assert self.date
 
-        # Check transaction types
-        assert (
-            self.trntype in INVEST_TRANSACTION_TYPES
-        ), "trntype %s is not valid, must be one of %s" % (
-            self.trntype,
-            INVEST_TRANSACTION_TYPES,
-        )
-
-        # Check transaction sub-types
+        # Each transaction type has slightly different requirements
+        if self.trntype == "BUYDEBT":
+            self.assert_valid_buydebt()
         if self.trntype == "BUYMF" or self.trntype == "BUYSTOCK":
-            assert (
-                self.trntype_detailed in INVEST_TRANSACTION_BUYTYPES
-            ), "trntype_detailed %s is not valid, must be one of %s" % (
-                self.trntype_detailed,
-                INVEST_TRANSACTION_BUYTYPES,
-            )
+            self.assert_valid_buystock()
         elif self.trntype == "INCOME":
-            assert (
-                self.trntype_detailed in INVEST_TRANSACTION_INCOMETYPES
-            ), "trntype_detailed %s is not valid, must be one of %s" % (
-                self.trntype_detailed,
-                INVEST_TRANSACTION_INCOMETYPES,
-            )
+            self.assert_valid_income()
         elif self.trntype == "INVBANKTRAN":
-            assert self.trntype_detailed in INVBANKTRAN_TYPES_DETAILED, (
-                "trntype_detailed %s is not valid for INVBANKTRAN, must be one of %s"
+            self.assert_valid_invbanktran()
+        elif self.trntype == "SELLDEBT":
+            self.assert_valid_selldebt()
+        elif self.trntype == "SELLMF" or self.trntype == "SELLSTOCK":
+            self.assert_valid_sellstock()
+        elif self.trntype == "TRANSFER":
+            self.assert_valid_transfer()
+        else:
+            raise AssertionError(
+                "trntype %s is not valid, must be one of %s"
                 % (
-                    self.trntype_detailed,
-                    INVBANKTRAN_TYPES_DETAILED,
+                    self.trntype,
+                    INVEST_TRANSACTION_TYPES,
                 )
             )
-        elif self.trntype == "SELLMF" or self.trntype == "SELLSTOCK":
-            assert (
-                self.trntype_detailed in INVEST_TRANSACTION_SELLTYPES
-            ), "trntype_detailed %s is not valid, must be one of %s" % (
-                self.trntype_detailed,
-                INVEST_TRANSACTION_SELLTYPES,
-            )
-        else:
-            assert (
-                self.trntype_detailed is None
-            ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
 
-        assert self.trntype == "TRANSFER" or self.amount
-        assert self.trntype == "INVBANKTRAN" or self.security_id
+    def assert_valid_buydebt(self):
+        assert (
+            self.trntype_detailed is None
+        ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
+        self.assert_valid_invbuy()
 
-        if self.trntype == "INVBANKTRAN":
-            pass
-        elif self.trntype == "INCOME":
-            assert self.security_id
-        else:
-            assert self.security_id
-            assert self.units
-            assert self.trntype == "TRANSFER" or self.unit_price
+    def assert_valid_buystock(self):
+        assert (
+            self.trntype_detailed in INVEST_TRANSACTION_BUYTYPES
+        ), "trntype_detailed %s is not valid, must be one of %s" % (
+            self.trntype_detailed,
+            INVEST_TRANSACTION_BUYTYPES,
+        )
+        self.assert_valid_invbuy()
+
+    def assert_valid_income(self):
+        assert (
+            self.trntype_detailed in INVEST_TRANSACTION_INCOMETYPES
+        ), "trntype_detailed %s is not valid, must be one of %s" % (
+            self.trntype_detailed,
+            INVEST_TRANSACTION_INCOMETYPES,
+        )
+        assert self.security_id
+        assert self.amount
+
+    def assert_valid_invbanktran(self):
+        assert (
+            self.trntype_detailed in INVBANKTRAN_TYPES_DETAILED
+        ), "trntype_detailed %s is not valid for INVBANKTRAN, must be one of %s" % (
+            self.trntype_detailed,
+            INVBANKTRAN_TYPES_DETAILED,
+        )
+        assert self.amount
+
+    def assert_valid_selldebt(self):
+        assert (
+            self.trntype_detailed is None
+        ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
+        self.assert_valid_invsell()
+
+    def assert_valid_sellstock(self):
+        assert (
+            self.trntype_detailed in INVEST_TRANSACTION_SELLTYPES
+        ), "trntype_detailed %s is not valid, must be one of %s" % (
+            self.trntype_detailed,
+            INVEST_TRANSACTION_SELLTYPES,
+        )
+        self.assert_valid_invsell()
+
+    def assert_valid_transfer(self):
+        assert (
+            self.trntype_detailed is None
+        ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
+        assert self.security_id
+        assert self.units
+
+    def assert_valid_invbuy(self):
+        assert self.security_id
+        assert self.units
+        assert self.unit_price
+        assert self.amount
+
+    def assert_valid_invsell(self):
+        assert self.security_id
+        assert self.units
+        assert self.unit_price
+        assert self.amount
 
 
 class BankAccount(Printable):

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -288,6 +288,11 @@ class InvestStatementLine(Printable):
 
     def assert_valid(self) -> None:
         """Ensure that fields have valid values"""
+        # Every transaction needs an ID and date
+        assert self.id
+        assert self.date
+
+        # Check transaction types
         assert (
             self.trntype in INVEST_TRANSACTION_TYPES
         ), "trntype %s is not valid, must be one of %s" % (
@@ -295,19 +300,8 @@ class InvestStatementLine(Printable):
             INVEST_TRANSACTION_TYPES,
         )
 
-        if self.trntype == "INVBANKTRAN":
-            assert self.trntype_detailed in INVBANKTRAN_TYPES_DETAILED, (
-                "trntype_detailed %s is not valid for INVBANKTRAN, must be one of %s"
-                % (
-                    self.trntype_detailed,
-                    INVBANKTRAN_TYPES_DETAILED,
-                )
-            )
-        elif self.trntype == "TRANSFER":
-            assert (
-                self.trntype_detailed is None
-            ), f"trntype_detailed '{self.trntype_detailed}' should be empty for TRANSFERS"
-        elif self.trntype == "BUYSTOCK":
+        # Check transaction sub-types
+        if self.trntype == "BUYSTOCK":
             assert (
                 self.trntype_detailed in INVEST_TRANSACTION_BUYTYPES
             ), "trntype_detailed %s is not valid, must be one of %s" % (
@@ -321,6 +315,14 @@ class InvestStatementLine(Printable):
                 self.trntype_detailed,
                 INVEST_TRANSACTION_INCOMETYPES,
             )
+        elif self.trntype == "INVBANKTRAN":
+            assert self.trntype_detailed in INVBANKTRAN_TYPES_DETAILED, (
+                "trntype_detailed %s is not valid for INVBANKTRAN, must be one of %s"
+                % (
+                    self.trntype_detailed,
+                    INVBANKTRAN_TYPES_DETAILED,
+                )
+            )
         elif self.trntype == "SELLSTOCK":
             assert (
                 self.trntype_detailed in INVEST_TRANSACTION_SELLTYPES
@@ -328,9 +330,11 @@ class InvestStatementLine(Printable):
                 self.trntype_detailed,
                 INVEST_TRANSACTION_SELLTYPES,
             )
+        else:
+            assert (
+                self.trntype_detailed is None
+            ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
 
-        assert self.id
-        assert self.date
         assert self.trntype == "TRANSFER" or self.amount
         assert self.trntype == "INVBANKTRAN" or self.security_id
 

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -150,6 +150,20 @@ NEWFILEUID:NONE
                         <UNITPRICE>225.63000</UNITPRICE>
                         <UNITS>4.00000</UNITS>
                     </TRANSFER>
+                    <INVEXPENSE>
+                        <INVTRAN>
+                            <FITID>8</FITID>
+                            <DTTRADE>20250101</DTTRADE>
+                            <MEMO>NRA Tax Adj</MEMO>
+                        </INVTRAN>
+                        <SECID>
+                            <UNIQUEID>AAPL</UNIQUEID>
+                            <UNIQUEIDTYPE>TICKER</UNIQUEIDTYPE>
+                        </SECID>
+                        <SUBACCTSEC>OTHER</SUBACCTSEC>
+                        <SUBACCTFUND>OTHER</SUBACCTFUND>
+                        <TOTAL>-0.29</TOTAL>
+                    </INVEXPENSE>
                 </INVTRANLIST>
             </INVSTMTRS>
         </INVSTMTTRNRS>
@@ -230,6 +244,18 @@ class OfxInvestLinesWriterTest(TestCase):
         invest_line.security_id = "MSFT"
         invest_line.units = Decimal("4")
         invest_line.unit_price = Decimal("225.63")
+        invest_line.assert_valid()
+        statement.invest_lines.append(invest_line)
+
+        invest_line = InvestStatementLine(
+            "8",
+            datetime(2025, 1, 1),
+            "NRA Tax Adj",
+            "INVEXPENSE",
+            None,
+            "AAPL",
+            Decimal("-0.29"),
+        )
         invest_line.assert_valid()
         statement.invest_lines.append(invest_line)
 

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -147,7 +147,6 @@ NEWFILEUID:NONE
                             <UNIQUEIDTYPE>TICKER</UNIQUEIDTYPE>
                         </SECID>
                         <SUBACCTSEC>OTHER</SUBACCTSEC>
-                        <SUBACCTFUND>OTHER</SUBACCTFUND>
                         <UNITPRICE>225.63000</UNITPRICE>
                         <UNITS>4.00000</UNITS>
                     </TRANSFER>

--- a/src/ofxstatement/tests/test_statement.py
+++ b/src/ofxstatement/tests/test_statement.py
@@ -135,3 +135,21 @@ class StatementTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             line.unit_price = None
             line.assert_valid()
+
+    def test_invexpense_line_validation(self) -> None:
+        line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
+        line.trntype = "INVEXPENSE"
+        line.amount = Decimal(1)
+        line.security_id = "AAPL"
+        line.assert_valid()
+        with self.assertRaises(AssertionError):
+            line.amount = None
+            line.assert_valid()
+        line.amount = Decimal(1)
+        with self.assertRaises(AssertionError):
+            line.trntype_detailed = "SOMETHING"
+            line.assert_valid()
+        line.trntype_detailed = None
+        with self.assertRaises(AssertionError):
+            line.security_id = None
+            line.assert_valid()


### PR DESCRIPTION
I'd like to be able to write out INVEXPENSE investment transactions as part of the schwab-ofxstatement plugin, so here is a proposal for adding support for that transaction type.

There are a number of commits here as I did some refactoring along the way to make my additions easier. To make it easier to review, I tried to keep refactors with no logic changes in separate commits from where I made logic changes. The tests passed after each commit.