### PR TITLE
Quiet the "License classifiers are deprecated." warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "Tool to convert proprietary bank statement to OFX format, suitable for importing to GnuCash"
 readme = "README.rst"
 requires-python = ">=3.9"
-license = { file="LICENSE.txt" }
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
@@ -20,7 +20,6 @@ classifiers = [
     "Topic :: Utilities",
     "Environment :: Console",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 keywords = ["ofx", "banking", "statement"]
 dependencies = [


### PR DESCRIPTION
During build, many of these warnings are emitted:

* Getting build dependencies for sdist...
/tmp/build-env-1i2ab45u/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/tmp/build-env-1i2ab45u/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************


A couple of changes to pyproject.toml resolves this.

ref: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license