### PR TITLE
Conversion report now reports invest-lines too

### DIFF
--- a/src/ofxstatement/tests/test_tool.py
+++ b/src/ofxstatement/tests/test_tool.py
@@ -38,7 +38,7 @@ class ToolTests(unittest.TestCase):
         self.assertEqual(ret, 0)
         self.assertEqual(
             self.log.getvalue().splitlines(),
-            ["INFO: Conversion completed: (0 lines) %s" % inputfname],
+            ["INFO: Conversion completed: (0 lines, 0 invest-lines) %s" % inputfname],
         )
 
     def test_convert_noconf(self) -> None:
@@ -64,7 +64,7 @@ class ToolTests(unittest.TestCase):
 
         self.assertEqual(
             self.log.getvalue().splitlines(),
-            ["INFO: Conversion completed: (0 lines) %s" % inputfname],
+            ["INFO: Conversion completed: (0 lines, 0 invest-lines) %s" % inputfname],
         )
 
     def test_convert_parseerror(self) -> None:

--- a/src/ofxstatement/tool.py
+++ b/src/ofxstatement/tool.py
@@ -206,9 +206,16 @@ def convert(args: argparse.Namespace) -> int:
         out.write(writer.toxml(pretty=args.pretty, encoding=encoding))
 
     n_lines = len(statement.lines)
+    n_invest_lines = len(statement.invest_lines)
     log.info(
-        "Conversion completed: (%d line%s) %s"
-        % (n_lines, "s" if n_lines != 1 else "", args.input)
+        "Conversion completed: (%d line%s, %d invest-line%s) %s"
+        % (
+            n_lines,
+            "s" if n_lines != 1 else "",
+            n_invest_lines,
+            "s" if n_invest_lines != 1 else "",
+            args.input,
+        )
     )
     return 0  # success
 


### PR DESCRIPTION
"Conversion completed" report only reported the number of Statement lines that were converted.  Now the report reports the number of invest-lines that were converted too.

Sample output:

$ ofxstatement convert -t fidelity History_for_Account_2BT949086.{csv,ofx}
INFO: Conversion completed: (0 lines, 1 invest-line) History_for_Account_2BT949086.csv

Updates the tests/test_tool.py too so that tests still pass.