### PR TITLE
Update `CURRATE` precision to 4 decimal places

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -160,7 +160,7 @@ class OfxWriter(object):
     def buildCurrency(self, tag: str, currency: Currency) -> None:
         self.tb.start(tag, {})
         self.buildText("CURSYM", currency.symbol)
-        self.buildAmount("CURRATE", currency.rate)
+        self.buildAmount("CURRATE", currency.rate, precision=4)
         self.tb.end(tag)
 
     def buildInvestTransactionList(self) -> None:

--- a/src/ofxstatement/tests/test_ofx.py
+++ b/src/ofxstatement/tests/test_ofx.py
@@ -71,7 +71,7 @@ NEWFILEUID:NONE
                         </CURRENCY>
                         <ORIGCURRENCY>
                             <CURSYM>EUR</CURSYM>
-                            <CURRATE>3.45</CURRATE>
+                            <CURRATE>3.4543</CURRATE>
                         </ORIGCURRENCY>
                     </STMTTRN>
                 </BANKTRANLIST>


### PR DESCRIPTION
Increase the precision of `CURRATE` for better accuracy.

Matches the precision shown in the spec examples:

<img width="409" height="145" alt="image" src="https://github.com/user-attachments/assets/b4b2c8e2-54a1-4eb2-91ac-57c01b039a7a" />
