### PR TITLE
Add INVBAL for investment account

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -213,6 +213,16 @@ class OfxWriter(object):
             self.buildInvestTransaction(line)
 
         tb.end("INVTRANLIST")
+
+        tb.start("INVBAL", {})
+        self.buildAmount("AVAILCASH", self.statement.end_balance, False)
+        tb.start("BAL", {})
+        self.buildText("NAME", "TOTAL CASH")
+        self.buildAmount("VALUE", self.statement.end_balance, False)
+        self.buildDateTime("DTASOF", self.statement.end_date, False)
+        tb.end("BAL")
+        tb.end("INVBAL")
+
         tb.end("INVSTMTRS")
         tb.end("INVSTMTTRNRS")
         tb.end("INVSTMTMSGSRSV1")


### PR DESCRIPTION
I am building a new fidelity csv parser for my beancount since Fidelity disabled their OFX server: https://github.com/zhou13/ofxstatement-fidelity
I noticed that ofxstatement does not generate `INVBAL` for investment account.