### PR TITLE
Added support for CUSIP securities (bonds, t-bills, etc)

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -1,6 +1,7 @@
 import codecs
-from typing import Optional, Union
-from datetime import datetime, date, time
+import re
+from typing import Optional
+from datetime import datetime, time
 from decimal import Decimal
 
 from xml.etree import ElementTree as etree
@@ -174,16 +175,20 @@ class OfxWriter(object):
         ):
             if security_id is None:
                 continue
-            tb.start("STOCKINFO", {})
+
+            # Detect a CUSIP and assume this is a DEBTINFO bond if so.
+            is_cusip = re.match(r"^[0-9A-Z]{9}$", security_id) is not None
+            tb.start("DEBTINFO", {}) if is_cusip else tb.start("STOCKINFO", {})
             tb.start("SECINFO", {})
             tb.start("SECID", {})
             self.buildText("UNIQUEID", security_id)
-            self.buildText("UNIQUEIDTYPE", "TICKER")
+            self.buildText("UNIQUEIDTYPE", "CUSIP" if is_cusip else "TICKER")
             tb.end("SECID")
             self.buildText("SECNAME", security_id)
-            self.buildText("TICKER", security_id)
+            if not is_cusip:
+                self.buildText("TICKER", security_id)
             tb.end("SECINFO")
-            tb.end("STOCKINFO")
+            tb.end("DEBTINFO" if is_cusip else "STOCKINFO")
 
         tb.end("SECLIST")
         tb.end("SECLISTMSGSRSV1")
@@ -241,7 +246,7 @@ class OfxWriter(object):
                 tran_type_detailed_tag_name = "BUYTYPE"
         elif line.trntype.startswith("SELL"):
             inner_tran_type_tag_name = "INVSELL"
-            if line.trntype == "SELLMF" or line.trntype == "SELLSTOCK":
+            if line.trntype in ("SELLMF", "SELLSTOCK"):
                 tran_type_detailed_tag_name = "SELLTYPE"
         elif line.trntype == "INCOME":
             tran_type_detailed_tag_name = "INCOMETYPE"
@@ -268,7 +273,12 @@ class OfxWriter(object):
 
         tb.start("SECID", {})
         self.buildText("UNIQUEID", line.security_id, False)
-        self.buildText("UNIQUEIDTYPE", "TICKER")
+        # Detect a CUSIP and set id_type correctly, if so.
+        is_cusip = (
+            line.security_id
+            and re.match(r"^[0-9A-Z]{9}$", line.security_id) is not None
+        )
+        self.buildText("UNIQUEIDTYPE", "CUSIP" if is_cusip else "TICKER")
         tb.end("SECID")
 
         self.buildText("SUBACCTSEC", "OTHER")

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -295,7 +295,7 @@ class InvestStatementLine(Printable):
         # Each transaction type has slightly different requirements
         if self.trntype == "BUYDEBT":
             self.assert_valid_buydebt()
-        if self.trntype == "BUYMF" or self.trntype == "BUYSTOCK":
+        elif self.trntype == "BUYMF" or self.trntype == "BUYSTOCK":
             self.assert_valid_buystock()
         elif self.trntype == "INCOME":
             self.assert_valid_income()

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -266,3 +266,70 @@ class OfxInvestLinesWriterTest(TestCase):
         writer.genTime = datetime(2021, 5, 1, 0, 0, 0)
 
         assert prettyPrint(writer.toxml()) == SIMPLE_OFX.lstrip().replace("\n", "\r\n")
+
+    def test_cusip_writes_debtinfo_and_cusip_type(self) -> None:
+        statement = Statement("BID", "ACCID", "USD")
+        statement.broker_id = "BROKERID"
+        statement.end_date = datetime(2024, 1, 1)
+
+        cusip_line = InvestStatementLine(
+            "1",
+            datetime(2023, 12, 15),
+            "Bond purchase",
+            "BUYDEBT",
+            None,
+            "123456ABC",
+            Decimal("-1000"),
+        )
+        cusip_line.units = Decimal("10")
+        cusip_line.unit_price = Decimal("100")
+        cusip_line.assert_valid()
+        statement.invest_lines.append(cusip_line)
+
+        stock_line = InvestStatementLine(
+            "2",
+            datetime(2023, 12, 20),
+            "Stock purchase",
+            "BUYSTOCK",
+            "BUY",
+            "MSFT",
+            Decimal("-200"),
+        )
+        stock_line.units = Decimal("1")
+        stock_line.unit_price = Decimal("200")
+        stock_line.assert_valid()
+        statement.invest_lines.append(stock_line)
+
+        writer = ofx.OfxWriter(statement)
+        writer.genTime = datetime(2024, 1, 1, 0, 0, 0)
+
+        _, _, payload = writer.toxml().partition("\r\n\r\n")
+        dom = xml.dom.minidom.parseString(payload)
+
+        def get_text(node, tag_name: str) -> str:
+            elems = node.getElementsByTagName(tag_name)
+            return (
+                elems[0].firstChild.nodeValue if elems and elems[0].firstChild else ""
+            )
+
+        # Security list should wrap CUSIP in DEBTINFO with UNIQUEIDTYPE CUSIP
+        debt_infos = dom.getElementsByTagName("DEBTINFO")
+        assert len(debt_infos) == 1
+        assert get_text(debt_infos[0], "UNIQUEID") == "123456ABC"
+        assert get_text(debt_infos[0], "UNIQUEIDTYPE") == "CUSIP"
+        assert not debt_infos[0].getElementsByTagName("TICKER")
+
+        stock_infos = dom.getElementsByTagName("STOCKINFO")
+        assert len(stock_infos) == 1
+        assert get_text(stock_infos[0], "UNIQUEID") == "MSFT"
+        assert get_text(stock_infos[0], "UNIQUEIDTYPE") == "TICKER"
+        assert get_text(stock_infos[0], "TICKER") == "MSFT"
+
+        # Transaction SECID blocks should also carry the correct id type
+        secid_nodes = dom.getElementsByTagName("SECID")
+        secids = {
+            get_text(node, "UNIQUEID"): get_text(node, "UNIQUEIDTYPE")
+            for node in secid_nodes
+        }
+        assert secids["123456ABC"] == "CUSIP"
+        assert secids["MSFT"] == "TICKER"


### PR DESCRIPTION
This PR adds support for CUSIP securities which are now listed under DEBTINFO with UNIQUEIDTYPE set to CUSIP. Test added: test_cusip_writes_debtinfo_and_cusip_type

Also, I fixed a logic bug in statement.py - I changed an if to an elif. I believe this was the intent. The bug prevented self.trntype "BUYDEBT" to ever be possible.

I'm new to using ofxstatement - thanks for creating/maintaining this project. I'm happy to change around the PR however you like, just let me know.
