### PR TITLE
Add required TFERACTION to TRANSFER

### DIFF
--- a/src/ofxstatement/ofx.py
+++ b/src/ofxstatement/ofx.py
@@ -248,8 +248,11 @@ class OfxWriter(object):
             inner_tran_type_tag_name = (
                 None  # income transactions don't have an envelope element
             )
+        elif line.trntype == "TRANSFER":
+            tran_type_detailed_tag_name = "TFERACTION"
+            inner_tran_type_tag_name = None
         else:
-            # INVEXPENSE and TRANSFER transactions don't have details or an envelope
+            # INVEXPENSE transactions don't have details or an envelope
             tran_type_detailed_tag_name = None
             inner_tran_type_tag_name = None
 

--- a/src/ofxstatement/statement.py
+++ b/src/ofxstatement/statement.py
@@ -55,6 +55,10 @@ INVEST_TRANSACTION_SELLTYPES = [
     "SELLSHORT",  # open short sale
 ]
 
+INVEST_TRANSACTION_TFERACTION = [
+    "IN",
+    "OUT",
+]
 INVEST_TRANSACTION_INCOMETYPES = [
     "CGLONG",
     "CGSHORT",
@@ -376,8 +380,11 @@ class InvestStatementLine(Printable):
 
     def assert_valid_transfer(self):
         assert (
-            self.trntype_detailed is None
-        ), f"trntype_detailed '{self.trntype_detailed}' should be empty for {self.trntype}"
+            self.trntype_detailed in INVEST_TRANSACTION_TFERACTION
+        ), "trntype_detailed %s is not valid, must be one of %s" % (
+            self.trntype_detailed,
+            INVEST_TRANSACTION_TFERACTION,
+        )
         assert self.security_id
         assert self.units
 

--- a/src/ofxstatement/tests/test_ofx_invest.py
+++ b/src/ofxstatement/tests/test_ofx_invest.py
@@ -137,6 +137,7 @@ NEWFILEUID:NONE
                         <SUBACCTFUND>OTHER</SUBACCTFUND>
                     </INVBANKTRAN>
                     <TRANSFER>
+                        <TFERACTION>IN</TFERACTION>
                         <INVTRAN>
                             <FITID>7</FITID>
                             <DTTRADE>20210103</DTTRADE>
@@ -239,7 +240,7 @@ class OfxInvestLinesWriterTest(TestCase):
         statement.invest_lines.append(invest_line)
 
         invest_line = InvestStatementLine(
-            "7", datetime(2021, 1, 3), "Journaled Shares", "TRANSFER"
+            "7", datetime(2021, 1, 3), "Journaled Shares", "TRANSFER", "IN"
         )
         invest_line.security_id = "MSFT"
         invest_line.units = Decimal("4")

--- a/src/ofxstatement/tests/test_statement.py
+++ b/src/ofxstatement/tests/test_statement.py
@@ -54,6 +54,7 @@ class StatementTests(unittest.TestCase):
     def test_transfer_line_validation(self) -> None:
         line = statement.InvestStatementLine("id", datetime(2020, 3, 25))
         line.trntype = "TRANSFER"
+        line.trntype_detailed = "IN"
         line.security_id = "ABC"
         line.units = Decimal(2)
         line.assert_valid()


### PR DESCRIPTION
This PR adds support for `TFERACTION` in a `TRANSFER` transaction.

The OFX specification requires that a `TRANSFER` transaction has a `TFERACTION` element to designates if the transaction is `IN` or `OUT` of the account.

```xml
 <xsd:complexType name="Transfer">
  <xsd:annotation>
   <xsd:documentation>
        The OFX element "TRANSFER" is of type "Transfer"
      </xsd:documentation>
  </xsd:annotation>
  <xsd:complexContent>
   <xsd:extension base="ofx:AbstractInvestmentTransaction">
    <xsd:sequence>
     <xsd:element name="SECID" type="ofx:SecurityId"/>
     <xsd:element name="SUBACCTSEC" type="ofx:SubAccountEnum"/>
     <xsd:element name="UNITS" type="ofx:QuantityType"/>
     <xsd:element name="TFERACTION" type="ofx:InOutEnum"/>
     <xsd:element name="POSTYPE" type="ofx:PositionTypeEnum"/>
     <xsd:element name="INVACCTFROM" type="ofx:InvestmentAccount" minOccurs="0"/>
     <xsd:element name="AVGCOSTBASIS" type="ofx:AmountType" minOccurs="0"/>
     <xsd:element name="UNITPRICE" type="ofx:UnitPriceType" minOccurs="0"/>
     <xsd:element name="DTPURCHASE" type="ofx:DateTimeType" minOccurs="0"/>
     <xsd:element name="INV401KSOURCE" type="ofx:Investment401kSourceEnum" minOccurs="0"/>
    </xsd:sequence>
   </xsd:extension>
  </xsd:complexContent>
 </xsd:complexType>
 ```
 
 
<img width="2202" height="944" alt="image" src="https://github.com/user-attachments/assets/653f7a24-5830-4a23-99af-c0b1bf17e87c" />
