### PR TITLE
Update Consorsbank plugin link to working PDF implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ Plugin                            Description
 
 `ofxstatement-germany`_           Plugin for several german banks (1822direkt and Postbank at the moment)
 `ofxstatement-dab`_               DAB Bank (Germany)
-`ofxstatement-consors`_           Consorsbank (Germany)
+`ofxstatement-consors`_           Consorsbank PDF statements (Germany)
 `ofxstatement-de-triodos`_        German Triodos Bank CSV statements (also works for GLS Bank)
 `ofxstatement-sp-freiburg`_       Sparkasse Freiburg-Nördlicher Breisgau (Germany)
 `ofxstatement-de-ing`_            Ing Diba Bank (Germany)
@@ -212,7 +212,7 @@ Plugin                            Description
 .. _ofxstatement-polish: https://github.com/yay6/ofxstatement-polish
 .. _ofxstatement-russian: https://github.com/gerasiov/ofxstatement-russian
 .. _ofxstatement-dab: https://github.com/JohannesKlug/ofxstatement-dab
-.. _ofxstatement-consors: https://github.com/JohannesKlug/ofxstatement-consors
+.. _ofxstatement-consors: https://github.com/eduralph/ofxstatement-consorsbank
 .. _ofxstatement-is-arionbanki: https://github.com/Dagur/ofxstatement-is-arionbanki
 .. _ofxstatement-be-triodos: https://github.com/renardeau/ofxstatement-be-triodos
 .. _ofxstatement-de-triodos: https://github.com/pianoslum/ofxstatement-de-triodos


### PR DESCRIPTION
## Summary

- Replaces the `ofxstatement-consors` link, which pointed to an empty sample project, with a working implementation at https://github.com/eduralph/ofxstatement-consorsbank
- Updates the description to reflect that this plugin parses PDF statements

Closes #380